### PR TITLE
changed navbar link from events to sponsors and removed routes to events

### DIFF
--- a/src/components/Navbar/index.jsx
+++ b/src/components/Navbar/index.jsx
@@ -38,7 +38,6 @@ export default class Navbar extends React.Component {
 					<div className="nav-section right" id="desktop-nav">
 						<ul className="nav-items">
 							<NavLink to="/about"><li>About</li></NavLink>
-							{ /* <NavLink to="/events"><li>Events</li></NavLink> */ }
 							<NavLink to="/sponsors"><li>Sponsors</li></NavLink>
 							<a href="https://members.uclaacm.com"><li className="button">Member Login</li></a>
 						</ul>
@@ -55,8 +54,7 @@ export default class Navbar extends React.Component {
 						<div id="hamburger-menu">
 							<ul className="nav-items">
 								<NavLink to="/about"><li>About</li></NavLink>
-								<NavLink to="/events"><li>Events</li></NavLink>
-								{ /* <NavLink to="/events"><li>Events</li></NavLink> */ }
+								<NavLink to="/sponsors"><li>Sponsors</li></NavLink>
 								<a href="https://members.uclaacm.com"><li className="button">Member Login</li></a>
 							</ul>
 						</div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,19 +24,16 @@ Number.prototype.map = function(fn) {
 class App extends React.Component {
 	render(){
 		return (
-			// <Provider store={store}>
-				<BrowserRouter onUpdate={() => window.scrollTo(0, 0)}>
-					<div>
-						<Switch>
-							<Route exact path="/" component={Home}/>
-							<Route exact path="/about" component={About}/>
-							<Route exact path="/events" component={Home}/>
-							<Route exact path="/sponsors" component={Sponsors}/>
-							<Redirect to="/"/>
-						</Switch>
-					</div>
-				</BrowserRouter>
-			// </Provider>
+			<BrowserRouter onUpdate={() => window.scrollTo(0, 0)}>
+				<div>
+					<Switch>
+						<Route exact path="/" component={Home}/>
+						<Route exact path="/about" component={About}/>
+						<Route exact path="/sponsors" component={Sponsors}/>
+						<Redirect to="/"/>
+					</Switch>
+				</div>
+			</BrowserRouter>
 		);
 	}
 }


### PR DESCRIPTION
We noticed that the mobile website has an events tab on the navbar which is deprecated. This PR changes that events tab to a sponsors tab.