### PR TITLE
Flagship events page

### DIFF
--- a/src/components/Events/Flagship/flagshipevent.jsx
+++ b/src/components/Events/Flagship/flagshipevent.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default class FlagshipEvent extends React.Component {
+	render() {
+		return (
+			<div className="flagship-event">
+				<img src={this.props.event.image} />
+				<h3>{this.props.event.name}</h3>
+				<p>{this.props.event.about}</p>
+			</div>
+		);
+	}
+} 

--- a/src/components/Events/Flagship/index.jsx
+++ b/src/components/Events/Flagship/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import FlagshipEvent from './flagshipevent';
+
+export default class FlagshipEvents extends React.Component {
+	render() {
+		return (
+			<div className="season-events">
+				<h3>{ this.props.events.season }</h3> 
+				{this.props.events.events.map(event => 
+					<FlagshipEvent key={event.name} event={event} />
+				)}
+			</div>
+		);
+	}
+}

--- a/src/components/Events/Flagship/style.scss
+++ b/src/components/Events/Flagship/style.scss
@@ -1,0 +1,58 @@
+.season-events {
+	text-align: left;
+	align-items: center;
+
+	.flagship-event {
+		display: grid;
+		grid-template-columns: 200px calc(100% - 200px);
+		grid-template-rows: 50px 150px;
+		padding-bottom: 20px;
+
+		img {
+			height: 200px;
+			width: 200px;
+			object-fit: cover;
+			border-radius: 1em;
+		}
+
+		h3 {
+			margin: 0 22px 14px;
+			grid-column-start: 2;
+			grid-row-start: 1;
+			align-self: end;
+		}
+
+		p {
+			grid-column-start: 2;
+			grid-row-start: 2;
+			align-self: start;
+		}
+	}
+	
+	@media (max-width:600px) {
+		.flagship-event {
+			grid-template-columns: 100%;
+			grid-template-rows: 50px 200px auto;
+
+			img {
+				grid-row-start: 2;
+				place-self: center;
+			}
+
+			h3 {
+				grid-row-start: 1;
+				grid-column-start: 1;
+				text-align: center;
+			}
+
+			p {
+				grid-row-start: 3;
+				grid-column-start: 1;
+				margin-top: 14px;
+				text-align: center;
+			}
+		}
+	}
+}
+
+

--- a/src/components/Events/index.jsx
+++ b/src/components/Events/index.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Config from 'config';
+
+import Navbar from 'components/Navbar';
+import Footer from 'components/Footer';
+import Banner from 'components/Banner';
+import FlagshipEvents from 'components/Events/Flagship';
+
+export default class Events extends React.Component {
+	render() {
+		return (
+			<div className="about-page">
+				<Navbar />
+				<Banner decorative />
+				<div className="content-section center">
+					<h2>Flagship Events</h2>
+					<div className="flagship-events">
+						{ Config.events.map(events => {
+							if (events.events.length !== 0) {
+								return <FlagshipEvents key={events.season} events={events} />
+							}
+						})}
+					</div>
+				</div>
+				<Footer />
+			</div>
+		);
+	}
+}

--- a/src/components/Navbar/index.jsx
+++ b/src/components/Navbar/index.jsx
@@ -38,6 +38,7 @@ export default class Navbar extends React.Component {
 					<div className="nav-section right" id="desktop-nav">
 						<ul className="nav-items">
 							<NavLink to="/about"><li>About</li></NavLink>
+							<NavLink to="/events"><li>Events</li></NavLink>
 							<NavLink to="/sponsors"><li>Sponsors</li></NavLink>
 							<a href="https://members.uclaacm.com"><li className="button">Member Login</li></a>
 						</ul>
@@ -54,6 +55,7 @@ export default class Navbar extends React.Component {
 						<div id="hamburger-menu">
 							<ul className="nav-items">
 								<NavLink to="/about"><li>About</li></NavLink>
+								<NavLink to="/events"><li>Events</li></NavLink>
 								<NavLink to="/sponsors"><li>Sponsors</li></NavLink>
 								<a href="https://members.uclaacm.com"><li className="button">Member Login</li></a>
 							</ul>

--- a/src/config/events.jsx
+++ b/src/config/events.jsx
@@ -1,0 +1,50 @@
+export default [
+    {
+        season: 'Quarterly',
+        events: [
+            {
+                name: 'General Meeting',
+                about: 'Come meet the ACM crew and committees and hear about all of the awesome events we\'re doing this quarter!',
+                image: '/images/carousal/01.jpg'
+            },
+            {
+                name: 'Hack on the Hill',
+                about: 'Our UCLA beginner-friendly hackathon! Come to makes new friends, eat great food, and learn more about the amazing technologies in tech! We also have mentors to guide you!',
+                image: '/images/carousal/01.jpg'
+            }
+        ]
+    },
+    {
+        season: 'Fall',
+        events: []
+    },
+    {
+        season: 'Winter',
+        events: [
+            {
+                name: 'Hacker Expo',
+                about: 'Look at all the cool stuff we made',
+                image: '/images/carousal/01.jpg'
+            },
+            {
+                name: 'California Capture the Flag',
+                about: 'Cyber\'s cool event of the year',
+                image: '/images/carousal/01.jpg'
+            }
+        ]
+    },
+    {
+        season: 'Spring',
+        events: [
+            {
+                name: 'CodeSprint LA',
+                about: 'Algorithm practice for prizes',
+                image: '/images/carousal/01.jpg'
+            }
+        ]
+    },
+    {
+        season: 'Summer',
+        events: []
+    }           
+]

--- a/src/config/index.jsx
+++ b/src/config/index.jsx
@@ -2,10 +2,12 @@ import Committees from './committees';
 import Carousal from './carousal';
 import Sponsors from './sponsors';
 import Officers from './officers';
+import Events from './events';
 
 export default {
 	committees: Committees,
 	carousal: Carousal,
 	sponsors: Sponsors,
 	officers: Officers,
+	events: Events,
 };

--- a/src/containers/events.jsx
+++ b/src/containers/events.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import EventsComponent from 'components/Events';
+
+export default class Events extends React.Component {
+	render() {
+		return <EventsComponent />;
+	}
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,7 @@ import {render} from 'react-dom';
 
 import Home from 'containers/home';
 import About from 'containers/about';
+import Events from 'containers/events';
 import Sponsors from 'containers/sponsors';
 
 // hack for convenience
@@ -29,6 +30,7 @@ class App extends React.Component {
 					<Switch>
 						<Route exact path="/" component={Home}/>
 						<Route exact path="/about" component={About}/>
+						<Route exact path="/events" component={Events}/>
 						<Route exact path="/sponsors" component={Sponsors}/>
 						<Redirect to="/"/>
 					</Switch>

--- a/src/main.scss
+++ b/src/main.scss
@@ -64,5 +64,6 @@ body {
 @import 'components/Home/Committees/style';
 @import 'components/About/style';
 @import 'components/About/Officers/style';
+@import 'components/Events/Flagship/style';
 @import 'components/Sponsors/style';
 @import 'components/Footer/style';


### PR DESCRIPTION
Added a page that displays the major events each quarter. 

Desktop view:
<img width="1280" alt="screen shot 2019-02-28 at 10 47 02 am" src="https://user-images.githubusercontent.com/23140162/53590333-5fa66280-3b46-11e9-8455-e12f136df88e.png">

Mobile view:
<img width="1280" alt="screen shot 2019-02-28 at 10 47 17 am" src="https://user-images.githubusercontent.com/23140162/53590277-41406700-3b46-11e9-8d53-e367e4e97738.png">
