### PR TITLE
Adds Teach LA Website to Committees

### DIFF
--- a/src/config/committees.jsx
+++ b/src/config/committees.jsx
@@ -53,6 +53,6 @@ export default [
 		class: 'teachla',
 		tagline: 'Learn It, Teach It',
 		image: '/images/committees/logo-teachla.svg',
-		link: 'https://www.facebook.com/teachlaucla/'
+		link: 'https://teachla.uclaacm.com'
 	}
 ]


### PR DESCRIPTION
Hey! This is a PR for adding the Teach LA Website to the committees object, replacing the previous Facebook page. ~~Right now this shouldn't be merged because the domain is not ready, but it's ready to merge as soon as we get the domain!~~ We just got the domain so we're good to merge!