### PR TITLE
Refactoring Navbar and Footer out of Individual Pages + Sticky Footer

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import Config from 'config';
 
 import Navbar from 'components/Navbar';
-import Button from 'components/Button';
-import Footer from 'components/Footer';
 import Banner from 'components/Banner';
 import Officers from 'components/About/Officers';
 
@@ -11,7 +9,6 @@ export default class About extends React.Component {
 	render() {
 		return (
 			<div className="about-page">
-				<Navbar />
 				<Banner decorative />
 				<div className="content-section">
 					<div className="ornament square-ornament">
@@ -49,7 +46,6 @@ export default class About extends React.Component {
 					<h2>Officers</h2>
 				</div>
 				<Officers officers={Config.officers} /><br /><br />
-				<Footer />
 			</div>
 		);
 	}

--- a/src/components/Events/index.jsx
+++ b/src/components/Events/index.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import Config from 'config';
 
-import Navbar from 'components/Navbar';
 import Banner from 'components/Banner';
-import Footer from 'components/Footer';
 import Calendar from 'components/Events/Calendar';
 
 export default class Events extends React.Component {
     render() {
         return (
             <div className='events-container'>
-               <Navbar/>
                <Banner decorative />
                <h2>Our Events</h2>
                <p>Our events are open to everyone, regardless of major, background, or experience!</p>
@@ -18,7 +15,6 @@ export default class Events extends React.Component {
                <br/><br/>
                <Calendar url={Config.events.calendar_url}/>
                <br/><br/><br/>
-               <Footer />
             </div>
         )
     }

--- a/src/components/Footer/style.scss
+++ b/src/components/Footer/style.scss
@@ -2,6 +2,7 @@
 	width: 100%;
 	min-height: 120px;
 	background-color: $acm-black;
+	flex-shrink: 0;
 
 	#footer-inner {
 		max-width: 1000px;

--- a/src/components/Home/index.jsx
+++ b/src/components/Home/index.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import Config from 'config';
 
-import Navbar from 'components/Navbar';
 import Button from 'components/Button';
-import Footer from 'components/Footer';
 import Banner from 'components/Banner';
 import Carousal from 'components/Home/Carousal';
 import Committees from 'components/Home/Committees';
@@ -12,7 +10,6 @@ export default class Home extends React.Component {
 	render() {
 		return (
 			<div className="home-page">
-				<Navbar />
 				<Banner />
 				<div className="content-section center">
 					<h2>The largest Computer Science community at UCLA</h2>
@@ -59,7 +56,6 @@ export default class Home extends React.Component {
 					</div>
 				</div>
 				<Carousal images={Config.carousal.images} />
-				<Footer />
 			</div>
 		);
 	}

--- a/src/components/Sponsors/index.jsx
+++ b/src/components/Sponsors/index.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import Config from 'config';
 
-import Navbar from 'components/Navbar';
 import Button from 'components/Button';
-import Footer from 'components/Footer';
 import Banner from 'components/Banner';
 
 export default class Sponsors extends React.Component {
 	render() {
 		return (
 			<div className="about-page">
-				<Navbar />
 				<Banner decorative />
 				<div className="content-section center">
 					<h2>Our Sponsors</h2>
@@ -30,7 +27,6 @@ export default class Sponsors extends React.Component {
 						<a href="mailto:acm@ucla.edu"><Button text="Contact Us" /></a>
 					</div><br /><br />
 				</div>
-				<Footer />
 			</div>
 		);
 	}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,6 +9,9 @@ import {render} from 'react-dom';
 
 // import {store} from 'reducers';
 
+import Footer from './components/Footer/';
+import Navbar from './components/Navbar';
+
 import Home from 'containers/home';
 import About from 'containers/about';
 import Sponsors from 'containers/sponsors';
@@ -26,14 +29,18 @@ class App extends React.Component {
 	render(){
 		return (
 			<BrowserRouter onUpdate={() => window.scrollTo(0, 0)}>
-				<div>
-					<Switch>
-						<Route exact path="/" component={Home}/>
-						<Route exact path="/about" component={About}/>
-						<Route exact path="/events" component={Events}/>
-						<Route exact path="/sponsors" component={Sponsors}/>
-						<Redirect to="/"/>
-					</Switch>
+				<div className="app-container">
+					<Navbar />
+					<div className="main-container">
+						<Switch>
+							<Route exact path="/" component={Home}/>
+							<Route exact path="/about" component={About}/>
+							<Route exact path="/events" component={Events}/>
+							<Route exact path="/sponsors" component={Sponsors}/>
+							<Redirect to="/"/>
+						</Switch>
+					</div>
+					<Footer />
 				</div>
 			</BrowserRouter>
 		);

--- a/src/main.scss
+++ b/src/main.scss
@@ -52,6 +52,16 @@ body {
 	color: $font-primary-color;
 }
 
+.app-container{
+	display: flex;
+	min-height: 100vh;
+	flex-direction: column;
+}
+
+.main-container {
+	flex: 1 0 auto;
+}
+
 /*************************************
  * Import CSS styles for components  *
  ************************************/


### PR DESCRIPTION
Hey there!

Had a quick chat with @vohndernet about a small problem with the website a few weeks ago, and this PR should solve that problem.

If you head to [the events page](https://www.uclaacm.com/events) on a tall enough of a screen, the footer won't pad out to the bottom of the screen, and you'll instead be left with an awkward amount of whitespace.

<img width="1345" alt="Screen Shot 2020-06-28 at 3 05 13 AM" src="https://user-images.githubusercontent.com/14893287/85944520-33daee80-b8ec-11ea-99b8-858758def085.png">

This PR fixes that problem by making the Footer component sticky via Flexbox.

<img width="1341" alt="Screen Shot 2020-06-28 at 3 05 54 AM" src="https://user-images.githubusercontent.com/14893287/85944533-4b19dc00-b8ec-11ea-9da2-dc4b534eb468.png">

Exciting stuff! I should've probably separated this other change, but along the way I also refactored how the Navbar and Footer components work. Currently each of the four pages (`Home`, `Events`, `About`, `Sponsors`) each individually imports `Navbar` and `Footer` and renders them inside their own page, but uses them identically. This PR moves it up to `main.jsx`, which should technically lighten each page load (albeit minimally). 

I had to do this to make the sticky footer work properly (as the footer needs to be a sibling element of the "main" app content). 

Let me know if there are any problems with this refactor + sticky footer!