### PR TITLE
Rebranding fast follow

### DIFF
--- a/src/components/About/style.scss
+++ b/src/components/About/style.scss
@@ -7,7 +7,7 @@
 .square-ornament {
 	height: 200px;
 	width: 200px;
-	border-radius: 20px;
+	border-radius: 40px;
 	background: $acm-tint;
 	transform: rotate(45deg);
 }
@@ -39,7 +39,7 @@
 	width: 250px;
 	left: 30px;
 	top: -65px;
-	border-radius: 25px;
+	border-radius: 50px;
 	background-image: url(/images/about1.png);
 	background-size: cover;
 	background-color: $acm-cobalt;
@@ -51,7 +51,7 @@
 	width: 50px;
 	right: -110px;
 	top: 0px;
-	border-radius: 5px;
+	border-radius: 10px;
 	background-color: $acm-cobalt;
 }
 
@@ -61,7 +61,7 @@
 	width: 18px;
 	right: -105px;
 	top: -25px;
-	border-radius: 2px;
+	border-radius: 4px; //Roudning up from 3.6px
 	background-color: $acm-cobalt;
 }
 


### PR DESCRIPTION
A minor fix that may have fallen through the cracks during rebranding on the `/about` page:

- updated `.square-splash`, `.square-ornament`, `.square-small`, and `.square-tiny` with the new border radii convention

|  Previous  | This PR  |
|---|---|
|  ![image](https://user-images.githubusercontent.com/23728476/95019183-c6d8a280-0618-11eb-86eb-9cda0724ee91.png) |  ![image](https://user-images.githubusercontent.com/23728476/95019153-a4468980-0618-11eb-8171-6425591ff601.png) |

Unresolved but noted issue:
The image next to the how to get involved section is a static png, so will need to be updated in a photo editor and cannot be done through CSS
![image](https://user-images.githubusercontent.com/23728476/95019246-0ef7c500-0619-11eb-90ca-32f72c872839.png)

