### PR TITLE
NaN solved

### DIFF
--- a/src/components/Events/Fall_GM/Fall_GM.js
+++ b/src/components/Events/Fall_GM/Fall_GM.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Banner from '../../Banner/Banner'
 import Countdown from 'react-countdown';
 
-const FALL_GM_2020_START_TIME = new Date('2020-10-05T18:30:00-0700'); //October 5th 2020 at 6:30 PDT
+const FALL_GM_2020_START_TIME = new Date('2020-10-05T18:30:00-07:00'); //October 5th 2020 at 6:30 PDT
 
 export default function FallGM() {
 	const calculateTimeStrings = ({days, hours, minutes, seconds}) => {


### PR DESCRIPTION
So @evazhog, you were right about it being an issue with old Safari browsers. Versions before 14 don't have as robust date parsing as newer Safari or Chrome browsers. Just need an extra colon in the time zone.

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/20938409/95117652-ed7d0300-0716-11eb-8e40-218e33d712fb.gif)
