### PR TITLE
Switch Actions to use Node 15.x (new latest), removes Node 12.x (old LTS)

### DIFF
--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node 12 isn't LTS anymore, 14.x is; and, 15 is latest, so we can build against that too!

Should be a trivial change.