### PR TITLE
fix: cleans up committees sidebar onScroll with `useEffect`

### DIFF
--- a/src/components/Committees/Sidebar/Sidebar.js
+++ b/src/components/Committees/Sidebar/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 function SidebarLink(props){
 	return (
@@ -12,15 +12,22 @@ function SidebarLink(props){
 }
 
 function Sidebar(props){
-	// TODO: this is a side effect, it needs to be done with useEffect and should be cleaned up
-
 	// Check if user has scrolled to the bottom of the page
 	const [bottom, setBottom] = useState(false);
-	window.onscroll = function() {
+	const scrollBottomListener = () => {
 		const difference = document.documentElement.scrollHeight - window.innerHeight;
 		const scrollposition = document.documentElement.scrollTop;
 		setBottom(difference - scrollposition <= 180);
 	};
+
+	useEffect(() => {
+		window.addEventListener('scroll', scrollBottomListener);
+
+		// cleanup
+		return () => {
+			window.removeEventListener('scroll', scrollBottomListener);
+		};
+	});
 
 
 	// Don't display sidebar if user has scrolled to the bottom of the screen

--- a/src/components/Committees/Sidebar/Sidebar.js
+++ b/src/components/Committees/Sidebar/Sidebar.js
@@ -27,7 +27,7 @@ function Sidebar(props){
 		return () => {
 			window.removeEventListener('scroll', scrollBottomListener);
 		};
-	});
+	}, []);
 
 
 	// Don't display sidebar if user has scrolled to the bottom of the screen


### PR DESCRIPTION
This is a short and sweet PR that resolves a small regression introduced in #108 - the `window.onScroll` is created as a side effect on render, but is never properly cleaned up. This resolves that by using the `useEffect` hook and returning a cleanup function to the hook.

As a side note: I make the re-render dependency list empty since I don't think a change in `bottom` should trigger a cleanup. 