### PR TITLE
Updates ESLint to ignore the `build` folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     sourceType: 'module',
   },
-  ignorePatterns: ['/build/**/**/*.js'],
+  ignorePatterns: ['/build/*'],
   plugins: ['react', 'import'],
   settings: {
     react: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     },
     sourceType: 'module',
   },
+  ignorePatterns: ['/build/**/**/*.js'],
   plugins: ['react', 'import'],
   settings: {
     react: {


### PR DESCRIPTION
super short PR - the eslint config did not ignore the build files, showing tons of irrelevant errors when running `npm run lint-js` after doing `npm start` at least once, since it was also scanning the build folder

this adds all the js files in the build folder to the eslint, fixing this issue