### PR TITLE
chore: ignores README-only changes for actions triggers

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,13 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
   schedule:
     - cron: '42 22 * * 2'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,13 @@ name: Lint
 
 on:
   push:
-    branches: [ main]
+    branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
 
 jobs:
   lint:

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -6,8 +6,12 @@ name: Node.js CI
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/README.md'
 
 jobs:
   build:


### PR DESCRIPTION
While working on #187, I noticed that we "waste" a bit of Actions time rebuilding, linting, and running CodeQL against PRs that only introduce changes to `README.md`. Since we aren't using a markdown linter like `remark`, these Actions are all going to be a no-op.

So, this PR disables these actions on commits that only change `README.md`. If this is useful, we may want to:

* expand the set of files that we don't run changes against
* push this change upstream to other react projects we use, particularly the react starters that Teach LA uses