### PR TITLE
Adds Design Instagram to committees page

### DIFF
--- a/data/committees.js
+++ b/data/committees.js
@@ -144,7 +144,6 @@ export default [
 				platform: 'instagram',
 				link: 'https://www.instagram.com/acmdesign.ucla',
 			},
-
 		],
 		infoCards: [
 			{

--- a/data/committees.js
+++ b/data/committees.js
@@ -140,6 +140,11 @@ export default [
 				platform: 'facebook',
 				link: 'https://www.facebook.com/groups/acmdesign',
 			},
+			{
+				platform: 'instagram',
+				link: 'https://www.instagram.com/acmdesign.ucla',
+			},
+
 		],
 		infoCards: [
 			{


### PR DESCRIPTION
Now that design has an Instagram that's up and running, this short PR adds the link to the committees page!