### PR TITLE
Update `committees.js` for NSO Tabling

### DIFF
--- a/components/Committees/CommitteeEventCard.js
+++ b/components/Committees/CommitteeEventCard.js
@@ -8,7 +8,7 @@ function CommitteeEventCard(props) {
             <div className="image-wrapper">
             {hasImage
                 ? <Image src={props.image.src} alt={props.image.alt} width={241.8} height={160}/>
-                : <Image src={`/images/committees/${props.committee}/${props.committee}_motif_base.png`} alt={props.image.alt} width={241.8} height={160} />
+                : <Image src={`/images/committees/${props.committee}/${props.committee}_motif_base.png`} alt={`base motif for ${props.name}`} width={241.8} height={160} />
             }
             </div>
             <h4 className="font-header text-bold">{props.title}</h4>

--- a/components/Committees/CommitteeSection.js
+++ b/components/Committees/CommitteeSection.js
@@ -13,6 +13,7 @@ function CommitteeProjects({committee}) {
 					const { image, title, desc } = card;
 					return (
 						<CommitteeEventCard
+							name={committee.name}
 							committee={committee.class}
 							image={image}
 							title={title}

--- a/components/Committees/CommitteeSection.js
+++ b/components/Committees/CommitteeSection.js
@@ -6,7 +6,7 @@ import Intro from './CommitteeSectionIntro';
 function CommitteeProjects({committee}) {
 	return (
 		<div className="body-wrapper">
-			<h3 className="font-header text-bold text-25x">Events and Projects</h3>
+			<h3 className="font-header text-bold text-25x"> Past Events and Projects</h3>
 			<div className="card-container">
 				{committee.infoCards.map((card) => {
 					// TODO: destructure class after renaming it

--- a/data/committees.js
+++ b/data/committees.js
@@ -39,14 +39,6 @@ export default [
 				desc: 'No prior knowledge required! We walk new students through navigating the Unity editor and build a working knowledge of the tools starting from the ground up.',
 			},
 			{
-				title: 'Advanced Unity track',
-				image: {
-					src: '',
-					alt: '',
-				},
-				desc: 'For students already confident in the fundamentals of Unity, we examine a different advanced topic each week.',
-			},
-			{
 				title: 'Artists track',
 				image: {
 					src: '',
@@ -82,22 +74,6 @@ export default [
 				desc: 'CodeSprintLA is UCLA\'s own Competitive Programming Competition organized by ACM ICPC. Competitive Programming is the activity (some call it a sport!) of writing programs to solve computational problems. You must be clever with your algorithm to solve the program in a given time limit. Individual or teams compete to solve the most problems!',
 			},
 			{
-				title: 'Estimathon',
-				image: {
-					src: '/images/committees/icpc/estimathon.png',
-					alt: 'Estimathon Flyer',
-				},
-				desc: 'Want to win COOL prizes for flexing your estimation skills? Come out to ACM ICPC’s Estimathon! You’ll compete in teams to come up with the best ~*confidence intervals*~ (fancy word for “estimates”) to difficult maths and science questions like, what\'s the volume of the earth\'s oceans in cubic km; or, how many social security numbers are prime? It is a mind-bending mixture of math, trivia, and pure unadulterated fun.',
-			},
-			{
-				title: 'Cyber x Hack x ICPC presents Bruin Quest',
-				image: {
-					src: '/images/committees/hack/bruin_quest.png',
-					alt: 'Flyer for Bruin Quest',
-				},
-				desc: 'Explore a virtual UCLA campus and complete fun challenges to compete for points, prizes, and the glory of being Bruin Quest champion.',
-			},
-			{
 				title: 'Project A*: Competitive Programming Workshops',
 				image: {
 					src: '/images/committees/icpc/A.png',
@@ -112,14 +88,6 @@ export default [
 					alt: 'Advanced Interview Prep Flyer',
 				},
 				desc: 'Are you ready to bring your coding interview skills to the next level? Are you worried about the upcoming fall recruiting season? Do your CS 32 algorithm skills feel rusty? 🤔 💭 Don’t worry, we’ve got you covered! ACM ICPC is hosting an ⚙️  Advanced ⚙️  Interview Prep workshop that’ll let you in on all of the secrets to acing your next technical interview. In this workshop, we will be going over advanced algorithms and data structures asked in even the most difficult phone and onsite interviews! 🖥️ ',
-			},
-			{
-				title: 'CP gym',
-				image: {
-					src: '/images/committees/icpc/gymnasium.png',
-					alt: 'Competitive Programming Gymnasium Flyer',
-				},
-				desc: 'Welcome to ACM ICPC Competitive Programming Gymnasium! 💪 Perhaps you attended our workshops the last two quarters and found problem-solving fun, perhaps you want to hone your algorithmic thinking and prepare for CS 180, or perhaps you just want to hang out, meet people, and have some fun! If any of that’s the case, then you’ve come to the right place!',
 			},
 		],
 		introImage: '/images/committees/icpc/icpc_motif_applied.png',
@@ -155,18 +123,6 @@ export default [
 				desc: 'We are finishing up our main project of rebranding ACM at UCLA including the logos, wordmarks, motifs, banners, and complete visual identities of each committee. The rebranding project started to correct the pain points of our previous branding, and position ACM at UCLA to appeal to a larger audience.',
 			},
 			{
-				title: 'Styleguide Update',
-				image: {
-					src: '/images/committees/design/styleguide.png',
-					alt: 'Styleguide Screenshot',
-				},
-				desc: (
-					<>
-						We are finishing the design styleguide which contains the new branding design assets necessary for all committees, and some do&apos;s and don&apos;ts with abiding by the new brand image. We are also extracting the styles used in the styleguide into a CSS framework that can be used by all ACM committees to create their sites in the ACM style. Check it out at <a href="https://design.uclaacm.com" target="_blank" rel="noopener noreferrer">design.uclaacm.com</a> and the <a href="github.com/uclaacm/Styleguide" target="_blank" rel="noopener noreferrer" >Github page</a>.
-					</>
-				),
-			},
-			{
 				title: 'UXLA: UI/UX Workshop Series',
 				image: {
 					src: '/images/committees/design/uxla_1.png',
@@ -182,23 +138,6 @@ export default [
 				},
 				desc: 'We are continuing 🍢 Design Tapas 🍢 this quarter - Come join us this week for a fresh dive into HTML/CSS for beginners! This technology is all over the way we interact with Internet and is essential to know for any web development - a couple of our officers will be demystifying this secret to constructing websites and making them look awesome through code!',
 			},
-			{
-				title: 'Design Tapas: Intro to Vector Art',
-				image: {
-					src: '/images/committees/design/design_tapas_webGL.png',
-					alt: 'Design Tapas Flyer',
-				},
-				desc: 'For this week’s Design Tapas, we’ve prepared a plate that’ll introduce you to the world of vector art. The secret to the clean and beautiful digital graphics you see all over the internet, we’ll teach you how to use vector art tools like Illustrator to make shapes work for your vision - including how they all come together to create a cohesive graphic!',
-			},
-			{
-				title: 'Live Design Sessions (April 15  & May 20)',
-				image: {
-					src: '/images/committees/design/live_session.png',
-					alt: 'Live Design Sessions Flyer',
-				},
-				desc: 'ACM Design will be having a ✨LIVE DESIGN✨ workshop - if you want to improve your graphic design skills or are just interested in the topic, come watch one of our crazy talented ACM Design officers design live on Figma 🙌 He will be going through his process on how to design from scratch and how to use composition, colors and other elements to elevate your designs 🔥',
-			},
-
 		],
 		introImage: '/images/committees/design/design_motif_applied.png',
 		mission: 'Our mission is to design, manage, and support the visual identity of ACM at UCLA. We create the club\'s branding, event banners, and more elements, while also doing workshops to teach UI/UX to the UCLA community.',
@@ -301,30 +240,6 @@ export default [
 					</>
 				),
 			},
-			{
-				title: 'Weekly Curriculum Meetings',
-				image: {
-					src: '/images/committees/teachLA/day-of-code-original.jpg',
-					alt: 'Teach LA member teaching two primary schoolers',
-				},
-				desc: 'Prepare for classes and speaker series, and find your favourite way to teach kids! And, in the process, learn more about the wonderful and mystical topics of computer science!',
-			},
-			{
-				title: 'Weekly Dev Team Meetings ',
-				image: {
-					src: '/images/committees/teachLA/editor.png',
-					alt: 'Image of Teach LA\'s Editor Project',
-				},
-				desc: 'Whether you’re a complete beginner in web development or a seasoned pro, our dev team meetings are a blend of training & development (where we cover both intro and intermediate web dev topics), and a chance to work on projects with a diverse team.',
-			},
-			{
-				title: 'Day of Code',
-				image: {
-					src: '',
-					alt: '',
-				},
-				desc: 'April 24 @ 9 AM - 12 PM PT: an event in collaboration with ACM W to introduce middle school students to Computer Science. We will be holding non-technical, intermediate, and technical activities over the course of the event, including an AI Ethics discussion and an activity that allows students to build their own website.',
-			},
 		],
 		introImage: '/images/committees/teachLA/teachLA_motif_applied.png',
 		mission: 'Our mission is to provide equal access to K-12 CS education in the Los Angeles area. We do this by teaching classes, running workshops and events, and writing software!',
@@ -370,22 +285,6 @@ export default [
 				},
 				desc: 'Our year-long mentorship program pairs underclassmen/those new to CS with upperclassmen who can offer advice on everything from internships to favorite spots in LA (pre-COVID, at least).',
 			},
-			{
-				title: 'ACM-W Conscience',
-				image: {
-					src: '/images/committees/w/zoom-heart.png',
-					alt: 'Screenshot from a weekly meeting of Conscience',
-				},
-				desc: 'Conscience, reminiscent of an abbreviated pronounced version of Com(puter)Science, is a weekly informal book club ACM-W holds to make sure the next generation of tech personnel is more informed than the last about social issues. Proverbially with the aim of “giving Silicon Valley a conscience”, we choose one audiobook each quarter to listen to together and openly discuss.',
-			},
-			{
-				title: 'Collaborations with other committees/orgs',
-				image: {
-					src: '',
-					alt: '',
-				},
-				desc: 'We co-host a variety of one-off events with other branches of ACM + external UCLA student orgs centered around making computer science as accessible and open as possible (e.g. Day of Code, WESP, QWER Hacks)!',
-			},
 		],
 		introImage: '/images/committees/w/w_motif_applied.png',
 		mission: 'Our goal is to promote diversity in tech through mentorship, networking, and professional development opportunities. We’re a safe space for everyone interested in computer science. :)',
@@ -420,12 +319,12 @@ export default [
 		],
 		infoCards: [
 			{
-				title: 'Video Game AI (Collaboration with ACM Game Studio)',
+				title: 'AI/ML Workshops',
 				image: {
 					src: '',
 					alt: '',
 				},
-				desc: 'ACM AI’s projects team collaborated with ACM Game Studio to develop AI for a fighting video game that would match the skill level of the player. This project made use of reinforcement learning, an advanced machine learning technique used to teach agents to act intelligently in complex environments.',
+				desc: 'This fall ACM AI is offering three workshop series: Beginner Track, Advanced Track, and Applied ML. Beginner Track is an introductory course that teaches fundamentals of machine learning and assumes no prior background in AI. Advanced Track is a more advanced machine learning course that covers more advanced deep learning topics and is designed for students who have already previously taken Beginner Track or have prior knowledge of machine learning fundamentals. Our Applied ML workshops series covers practical skills needed to apply machine learning theory to real world problems and is designed for students who already have knowledge of machine learning fundamentals.',
 			},
 			{
 				title: 'You Belong in AI! Podcast',
@@ -440,40 +339,12 @@ export default [
 				),
 			},
 			{
-				title: 'AI Course for High School Students (Collaboration with ACM Teach LA)',
+				title: 'Video Game AI (Collaboration with ACM Game Studio)',
 				image: {
 					src: '',
 					alt: '',
 				},
-				desc: (
-					<>
-						ACM AI’s Outreach team collaborates with ACM TeachLA to teach an introductory AI course to local high school students in Los Angeles. An overview of this course content can be found at <a href="https://teachla.uclaacm.com/classes/ml" target="_blank" rel="noopener noreferrer">teachla.uclaacm.com/ classes/ml</a>.
-					</>
-				),
-			},
-			{
-				title: 'AI/ML Workshops',
-				image: {
-					src: '',
-					alt: '',
-				},
-				desc: 'This fall ACM AI is offering three workshop series: Beginner Track, Advanced Track, and Applied ML. Beginner Track is an introductory course that teaches fundamentals of machine learning and assumes no prior background in AI. Advanced Track is a more advanced machine learning course that covers more advanced deep learning topics and is designed for students who have already previously taken Beginner Track or have prior knowledge of machine learning fundamentals. Our Applied ML workshops series covers practical skills needed to apply machine learning theory to real world problems and is designed for students who already have knowledge of machine learning fundamentals.',
-			},
-			{
-				title: 'Demystifying AI',
-				image: {
-					src: '',
-					alt: '',
-				},
-				desc: 'It is important for all people, including those who do not work in technology to understand the impacts and ethical implications of the increasing usage of AI in modern society. Demystifying AI is an event designed for UCLA students of all majors to learn about AI and its pervasive impacts.',
-			},
-			{
-				title: 'AI Research Panel',
-				image: {
-					src: '',
-					alt: '',
-				},
-				desc: 'UCLA is one of the world’s leading AI research producing institutions. ACM AI will be hosting a panel of world-class AI researchers from UCLA in a discussion on their ongoing work at UCLA, the greater AI research landscape, and how undergraduates can get involved.',
+				desc: 'ACM AI’s projects team collaborated with ACM Game Studio to develop AI for a fighting video game that would match the skill level of the player. This project made use of reinforcement learning, an advanced machine learning technique used to teach agents to act intelligently in complex environments.',
 			},
 		],
 		introImage: '/images/committees/ai/ai_motif_applied.png',

--- a/data/committees.js
+++ b/data/committees.js
@@ -85,7 +85,7 @@ export default [
 				title: 'Estimathon',
 				image: {
 					src: '/images/committees/icpc/estimathon.png',
-					alt: '',
+					alt: 'Estimathon Flyer',
 				},
 				desc: 'Want to win COOL prizes for flexing your estimation skills? Come out to ACM ICPC’s Estimathon! You’ll compete in teams to come up with the best ~*confidence intervals*~ (fancy word for “estimates”) to difficult maths and science questions like, what\'s the volume of the earth\'s oceans in cubic km; or, how many social security numbers are prime? It is a mind-bending mixture of math, trivia, and pure unadulterated fun.',
 			},
@@ -101,7 +101,7 @@ export default [
 				title: 'Project A*: Competitive Programming Workshops',
 				image: {
 					src: '/images/committees/icpc/A.png',
-					alt: '',
+					alt: 'ICPC Project A* Flyer',
 				},
 				desc: 'All you need is a passion for problem-solving! Whether you are completely new to competitive programming (or even CS!), or a veteran coder we have a learning opportunity for you this Fall. Introducing Project A*, our weekly algorithm academy! Our Intro to Competitive Programming track will cover all the essentials from the bottom up to get you started in competitive programming. The Advanced Training track will delve deeper into more complicated data structures and algorithms to help you compete at the highest level.',
 			},
@@ -109,7 +109,7 @@ export default [
 				title: 'Advanced Interview Prep',
 				image: {
 					src: '/images/committees/icpc/interview_advanced.png',
-					alt: '',
+					alt: 'Advanced Interview Prep Flyer',
 				},
 				desc: 'Are you ready to bring your coding interview skills to the next level? Are you worried about the upcoming fall recruiting season? Do your CS 32 algorithm skills feel rusty? 🤔 💭 Don’t worry, we’ve got you covered! ACM ICPC is hosting an ⚙️  Advanced ⚙️  Interview Prep workshop that’ll let you in on all of the secrets to acing your next technical interview. In this workshop, we will be going over advanced algorithms and data structures asked in even the most difficult phone and onsite interviews! 🖥️ ',
 			},
@@ -117,7 +117,7 @@ export default [
 				title: 'CP gym',
 				image: {
 					src: '/images/committees/icpc/gymnasium.png',
-					alt: '',
+					alt: 'Competitive Programming Gymnasium Flyer',
 				},
 				desc: 'Welcome to ACM ICPC Competitive Programming Gymnasium! 💪 Perhaps you attended our workshops the last two quarters and found problem-solving fun, perhaps you want to hone your algorithmic thinking and prepare for CS 180, or perhaps you just want to hang out, meet people, and have some fun! If any of that’s the case, then you’ve come to the right place!',
 			},
@@ -158,7 +158,7 @@ export default [
 				title: 'Styleguide Update',
 				image: {
 					src: '/images/committees/design/styleguide.png',
-					alt: '',
+					alt: 'Styleguide Screenshot',
 				},
 				desc: (
 					<>
@@ -170,7 +170,7 @@ export default [
 				title: 'UXLA: UI/UX Workshop Series',
 				image: {
 					src: '/images/committees/design/uxla_1.png',
-					alt: '',
+					alt: 'UI/UX Workshop Series Flyer',
 				},
 				desc: 'Come join ACM Design\'s second workshop series of the quarter, UXLA! UXLA will cover core aspects of the UI/UX process. Come join us for our first of four workshops, Intro to UI/UX 💡 This week, we will cover the higher level goals of UI/UX, define terms like "user research" and "wireframes", and analyze companies that use good UI/UX practices!',
 			},
@@ -178,7 +178,7 @@ export default [
 				title: 'Design Tapas: HTML/CSS',
 				image: {
 					src: '/images/committees/design/design_tapas_3D_modeling.png',
-					alt: '',
+					alt: 'Design Tapas Flyer',
 				},
 				desc: 'We are continuing 🍢 Design Tapas 🍢 this quarter - Come join us this week for a fresh dive into HTML/CSS for beginners! This technology is all over the way we interact with Internet and is essential to know for any web development - a couple of our officers will be demystifying this secret to constructing websites and making them look awesome through code!',
 			},
@@ -186,7 +186,7 @@ export default [
 				title: 'Design Tapas: Intro to Vector Art',
 				image: {
 					src: '/images/committees/design/design_tapas_webGL.png',
-					alt: '',
+					alt: 'Design Tapas Flyer',
 				},
 				desc: 'For this week’s Design Tapas, we’ve prepared a plate that’ll introduce you to the world of vector art. The secret to the clean and beautiful digital graphics you see all over the internet, we’ll teach you how to use vector art tools like Illustrator to make shapes work for your vision - including how they all come together to create a cohesive graphic!',
 			},
@@ -194,7 +194,7 @@ export default [
 				title: 'Live Design Sessions (April 15  & May 20)',
 				image: {
 					src: '/images/committees/design/live_session.png',
-					alt: '',
+					alt: 'Live Design Sessions Flyer',
 				},
 				desc: 'ACM Design will be having a ✨LIVE DESIGN✨ workshop - if you want to improve your graphic design skills or are just interested in the topic, come watch one of our crazy talented ACM Design officers design live on Figma 🙌 He will be going through his process on how to design from scratch and how to use composition, colors and other elements to elevate your designs 🔥',
 			},
@@ -277,7 +277,7 @@ export default [
 				title: 'Synchronous and Asynchronous Classes',
 				image: {
 					src: '/images/committees/teachLA/brockton-original.jpg',
-					alt: 'Teach LA member teaching two primary schoolers.',
+					alt: 'Teach LA members with a class they are teaching.',
 				},
 				desc: 'Teach remote classes on Scratch, Python, Web Development, App Development (w/ React Native), and AI/ML (w/ ACM AI Outreach)! No prior CS experience required, and we like all majors!',
 			},
@@ -285,7 +285,7 @@ export default [
 				title: 'Speaker Series & Events',
 				image: {
 					src: '/images/committees/teachLA/speaker-events.jpg',
-					alt: '',
+					alt: 'Students and instructors from an event',
 				},
 				desc: 'Help run one-off virtual events like Day of Code (with ACM-W), “What CS in College is Like”, “Diversity in CS”, “Bias in AI & ML”, or “Hacking for Good!”! Here, we especially value diverse experiences, including CS backgrounds and majors.',
 			},
@@ -305,7 +305,7 @@ export default [
 				title: 'Weekly Curriculum Meetings',
 				image: {
 					src: '/images/committees/teachLA/day-of-code-original.jpg',
-					alt: '',
+					alt: 'Teach LA member teaching two primary schoolers',
 				},
 				desc: 'Prepare for classes and speaker series, and find your favourite way to teach kids! And, in the process, learn more about the wonderful and mystical topics of computer science!',
 			},
@@ -374,7 +374,7 @@ export default [
 				title: 'ACM-W Conscience',
 				image: {
 					src: '/images/committees/w/zoom-heart.png',
-					alt: '',
+					alt: 'Screenshot from a weekly meeting of Conscience',
 				},
 				desc: 'Conscience, reminiscent of an abbreviated pronounced version of Com(puter)Science, is a weekly informal book club ACM-W holds to make sure the next generation of tech personnel is more informed than the last about social issues. Proverbially with the aim of “giving Silicon Valley a conscience”, we choose one audiobook each quarter to listen to together and openly discuss.',
 			},

--- a/data/committees.js
+++ b/data/committees.js
@@ -265,7 +265,7 @@ export default [
 				title: 'Student Panel Series',
 				image: {
 					src: '/images/committees/w/startup-panel.png',
-					alt: 'A large garthering of WESP participants outside B-Plate the cafeteria.',
+					alt: 'Flyer for student panel with title "From Idea to Prototype to Business" and the speakers\' names ',
 				},
 				desc: 'We invite current and past students to share the wisdom they’ve gained from a variety of experiences, including entrepreneurship and the Grace Hopper Conference!',
 			},
@@ -273,7 +273,7 @@ export default [
 				title: 'WESP',
 				image: {
 					src: '/images/committees/w/wesp.png',
-					alt: 'A large garthering of WESP participants outside B-Plate the cafeteria.',
+					alt: 'A large gathering of WESP participants outside B-Plate the cafeteria.',
 				},
 				desc: 'The Women in Engineering Stayover Program is our annual event (pre-coronavirus) put on with WATT and SWE to showcase what UCLA Engineering (and UCLA Dining) has to offer to prospective students!',
 			},


### PR DESCRIPTION
Resolves #180 

Replaces "Events and Projects" with "Past Events and Projects"
Adds alt tag to every image that doesn't have one, and a general alt for events with no images that use the base committee motif.