### PR TITLE
disables `@next/no-img-element` in relevant areas, and adds `TODO` comments where needed

### DIFF
--- a/components/CommitteeSpread.js
+++ b/components/CommitteeSpread.js
@@ -8,6 +8,7 @@ function Committee(props){
 			href={`/committees#${props.committee.class}`}
 		>
 			{/* TODO: use next image without breaking deploy */}
+			{/* eslint-disable-next-line @next/next/no-img-element */}
 			<img src={props.committee.image} layout='fill' alt={`Logo and Wordmark for ACM ${props.committee.name}`} />
 			<div className="info">
 				<p>{props.committee.tagline}</p>

--- a/components/Committees/CommitteeSection.js
+++ b/components/Committees/CommitteeSection.js
@@ -35,6 +35,7 @@ function CommitteeSection(props) {
       {/* Header image */}
 			{/* TODO: use next image without breaking deploy */}
       <div className={`committee-header ${committee.class}`}>
+				{/* eslint-disable-next-line @next/next/no-img-element */}
 				<img src={committee.image} alt={`${committee.name}'s logo`} />
       </div>
       {/* Committee Intro */}

--- a/components/Committees/Sidebar.js
+++ b/components/Committees/Sidebar.js
@@ -8,8 +8,9 @@ function SidebarLink(props){
 			href={`#${props.committee.class}`}
 		>
 			<div className="committee-sidebar-image">
+				{/* TODO: resolve next/image issue */}
+				{/* eslint-disable-next-line @next/next/no-img-element */}
 				<img src={props.committee.image} alt={`Logo and Wordmark for ACM ${props.committee.name}`} />
-				{/* TODO: use next image without breaking deploy */}
 			</div>
 		</a>
 	);

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -29,6 +29,7 @@ function Footer(){
 				<div id="netlify-badge">
 					<a href="https://www.netlify.com" target="_BLANK" rel="noopener noreferrer">
 						{/* TODO: resolve 404 with <Image /> component */}
+						{/* eslint-disable-next-line @next/next/no-img-element */}
 						<img src="https://www.netlify.com/img/global/badges/netlify-light.svg" alt="Deploys by Netlify" />
 					</a>
 				</div>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -59,6 +59,8 @@ export default class Navbar extends React.Component {
 				<div id="navbar-inner">
 					<Link href="/">
 						<a id="nav-title" className="nav-section left">
+							{/* TODO: resolve next/image issue */}
+							{/* eslint-disable-next-line @next/next/no-img-element */}
 							<img src={'/images/acm_wordmark&logo.svg'} id="acm-logo" alt="ACM at UCLA Logo"></img>
 							{/* TODO: use next image without breaking deploy */}
 						</a>

--- a/pages/about.js
+++ b/pages/about.js
@@ -21,6 +21,8 @@ function About() {
 			<Banner decorative />
 			<div className={styles['content-section']}>
 				<div className={`${styles.ornament} ${styles['square-ornament']}`}>
+					{/* TODO: resolve next/image issue */}
+					{/* eslint-disable-next-line @next/next/no-img-element */}
 					<img className={styles['square-splash']} src='/images/about1.png' alt="a picture of acm students at our annual CS BBQ!"/>
 					{/* TODO: use next image without breaking deploy */}
 					<div className={styles['square-small']} />


### PR DESCRIPTION
Resolving our issues with `next/image` is already on the roadmap with #188. In the meantime, as pointed out in #216, we have some noisy errors that don't particularly help us. This PR disables rules *just for those lines*!