### PR TITLE
per-page SEO (meta tags, opengraph) via `next-seo`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3535,6 +3535,11 @@
         }
       }
     },
+    "next-seo": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/next-seo/-/next-seo-4.26.0.tgz",
+      "integrity": "sha512-5TqywQ3XAwqdmEU1AyNZjR7WdDKFTkDD8aBtgQelPvzBUEy8i0mTjtiw+09jhiHFNik6FqS8uPKCaYcY6jRgSQ=="
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.15",
     "next": "11.1.0",
+    "next-seo": "^4.26.0",
     "react": "^17.0.2",
     "react-countdown": "^2.3.2",
     "react-dom": "^17.0.2",

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,3 +1,4 @@
+import { NextSeo } from 'next-seo';
 import Image from 'next/image';
 import React from 'react';
 
@@ -17,75 +18,88 @@ function About() {
 	const { officers } = data;
 	return (
 		<Layout>
-		<div className={styles['about-page']}>
-			<Banner decorative />
-			<div className={styles['content-section']}>
-				<div className={`${styles.ornament} ${styles['square-ornament']}`}>
-					{/* TODO: resolve next/image issue */}
-					{/* eslint-disable-next-line @next/next/no-img-element */}
-					<img className={styles['square-splash']} src='/images/about1.png' alt="a picture of acm students at our annual CS BBQ!"/>
-					{/* TODO: use next image without breaking deploy */}
-					<div className={styles['square-small']} />
-					<div className={styles['square-tiny']} />
-				</div>
-				<div className={styles['text-section']}>
-					<h1>What is ACM?</h1>
-					<p>As a student chapter of the international <a href="https://www.acm.org" target="_blank" rel="noreferrer noopener">Association for Computing Machinery,</a> ACM at UCLA is the largest Computer Science student organization at UCLA and in Southern California. We welcome students of all backgrounds and skill levels to join our community and share our love for technology!</p>
-					<p>
-						With events such as infosessions, workshops, speaker panels, hackathons, and competitions,
-						we cover a variety of topics including artificial intelligence, virtual reality, cybersecurity,
-						mobile and web development, diversity initiatives, community outreach, and much more.
-						Our events are <strong>open to everyone</strong>, regardless of major or experience!
-					</p>
-				</div>
-			</div>
-			<div className={styles['content-section']}>
-				<div className={`${styles.ornament} ${styles['image-ornament']} ${styles['image-ornament-right']}`}>
-					<Image src={acmCommittees} alt="the logos of all ACM committees" priority={true} />
-				</div>
-				<div className={styles['text-section']}>
-					<h1>What are ACM committees?</h1>
-					<p>
-						ACM is comprised of eight committees — each serving a different topic and mission.
-						We strive to cover a plethora of interests and encourage members to explore new topics, too!
-					</p>
-				</div>
-			</div>
-			<div className={styles['content-section']}>
-				<div className={`${styles.ornament} ${styles['image-ornament']} ${styles['image-ornament-right']}`}>
-					<Image src={acmHowToJoin} alt="photos of acm events" />
-				</div>
-				<div className={styles['text-section']}>
-					<h1>How do I get involved?</h1>
-					<p>
-						No matter what your background or major is,
-						we would love to have you at our events and activities!
-					</p>
-					<p>
-						To keep up with what&rsquo;s happening, we recommend joining&nbsp;
-						<a href="https://members.uclaacm.com" target="_blank" rel="noreferrer noopener">
-							our membership portal
-						</a>,&nbsp;
-						<a href="https://www.facebook.com/groups/uclaacm" target="_blank" rel="noreferrer noopener">
-							our Facebook group
-						</a>, and&nbsp;
-						<a href="http://eepurl.com/c5pE6P" target="_blank" rel="noreferrer noopener">
-							our weekly newsletter
-						</a>.&nbsp;
-						We will keep you up to date with everything ACM, and earning points on the portal
-						might even earn you a prize!
-					</p>
-					<p>Here&rsquo;s our social media, where you can see what we&rsquo;re up to:</p>
-					<div className={styles['social-media']}>
-						<SocialMedia/>
+			<NextSeo
+				title="About | ACM at UCLA"
+				description="As a student chapter of the international Association for Computing Machinery,</a> ACM at UCLA is the largest Computer Science student organization at UCLA and in Southern California. We welcome students of all backgrounds and skill levels to join our community and share our love for technology!"
+				openGraph={{
+					images: [
+						{
+							url: 'https://www.uclaacm.com/images/logo.png',
+							width: 1200,
+							height: 1200,
+							alt: 'The ACM at UCLA logo',
+						},
+					],
+					site_name: 'ACM at UCLA',
+				}}
+			/>
+			<div className={styles['about-page']}>
+				<Banner decorative />
+				<div className={styles['content-section']}>
+					<div className={`${styles.ornament} ${styles['square-ornament']}`}>
+						{/* TODO: resolve next/image issue */}
+						{/* eslint-disable-next-line @next/next/no-img-element */}
+						<img className={styles['square-splash']} src='/images/about1.png' alt="a picture of acm students at our annual CS BBQ!"/>
+						{/* TODO: use next image without breaking deploy */}
+						<div className={styles['square-small']} />
+						<div className={styles['square-tiny']} />
+					</div>
+					<div className={styles['text-section']}>
+						<h1>What is ACM?</h1>
+						<p>As a student chapter of the international <a href="https://www.acm.org" target="_blank" rel="noreferrer noopener">Association for Computing Machinery,</a> ACM at UCLA is the largest Computer Science student organization at UCLA and in Southern California. We welcome students of all backgrounds and skill levels to join our community and share our love for technology!</p>
+						<p>
+							{/* eslint-disable-next-line max-len */}
+							With events such as infosessions, workshops, speaker panels, hackathons, and competitions, we cover a variety of topics including artificial intelligence, virtual reality, cybersecurity, mobile and web development, diversity initiatives, community outreach, and much more. Our events are <strong>open to everyone</strong>, regardless of major or experience!
+						</p>
 					</div>
 				</div>
+				<div className={styles['content-section']}>
+					<div className={`${styles.ornament} ${styles['image-ornament']} ${styles['image-ornament-right']}`}>
+						<Image src={acmCommittees} alt="the logos of all ACM committees" priority={true} />
+					</div>
+					<div className={styles['text-section']}>
+						<h1>What are ACM committees?</h1>
+						<p>
+							ACM is comprised of eight committees — each serving a different topic and mission.
+							We strive to cover a plethora of interests and encourage members to explore new topics, too!
+						</p>
+					</div>
+				</div>
+				<div className={styles['content-section']}>
+					<div className={`${styles.ornament} ${styles['image-ornament']} ${styles['image-ornament-right']}`}>
+						<Image src={acmHowToJoin} alt="photos of acm events" />
+					</div>
+					<div className={styles['text-section']}>
+						<h1>How do I get involved?</h1>
+						<p>
+							No matter what your background or major is,
+							we would love to have you at our events and activities!
+						</p>
+						<p>
+							To keep up with what&rsquo;s happening, we recommend joining&nbsp;
+							<a href="https://members.uclaacm.com" target="_blank" rel="noreferrer noopener">
+								our membership portal
+							</a>,&nbsp;
+							<a href="https://www.facebook.com/groups/uclaacm" target="_blank" rel="noreferrer noopener">
+								our Facebook group
+							</a>, and&nbsp;
+							<a href="http://eepurl.com/c5pE6P" target="_blank" rel="noreferrer noopener">
+								our weekly newsletter
+							</a>.&nbsp;
+							We will keep you up to date with everything ACM, and earning points on the portal
+							might even earn you a prize!
+						</p>
+						<p>Here&rsquo;s our social media, where you can see what we&rsquo;re up to:</p>
+						<div className={styles['social-media']}>
+							<SocialMedia/>
+						</div>
+					</div>
+				</div>
+				<div className={`${styles['content-section']} ${styles.leadership}`}>
+					<h2>Leadership</h2>
+					<Officers officers={officers} />
+				</div>
 			</div>
-			<div className={`${styles['content-section']} ${styles.leadership}`}>
-				<h2>Leadership</h2>
-				<Officers officers={officers} />
-			</div>
-		</div>
 		</Layout>
 	);
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -20,7 +20,7 @@ function About() {
 		<Layout>
 			<NextSeo
 				title="About | ACM at UCLA"
-				description="As a student chapter of the international Association for Computing Machinery,</a> ACM at UCLA is the largest Computer Science student organization at UCLA and in Southern California. We welcome students of all backgrounds and skill levels to join our community and share our love for technology!"
+				description="As a student chapter of the international Association for Computing Machinery, ACM at UCLA is the largest Computer Science student organization at UCLA and in Southern California. We welcome students of all backgrounds and skill levels to join our community and share our love for technology!"
 				openGraph={{
 					images: [
 						{

--- a/pages/committees.js
+++ b/pages/committees.js
@@ -1,5 +1,7 @@
+import { NextSeo } from 'next-seo';
 import Image from 'next/image';
 import React from 'react';
+
 import Banner from '../components/Banner';
 import CommitteeSection from '../components/Committees/CommitteeSection';
 import Navigation from '../components/Committees/Sidebar';
@@ -28,6 +30,21 @@ function CommitteesPage() {
 	const { committees } = data;
 	return (
 		<Layout>
+			<NextSeo
+				title="Committees | ACM at UCLA"
+				description="ACM comprises eight committees, each serving a unique topic and mission. Learn more about Studio, ICPC, Design, Cyber, Teach LA, W, AI, and Hack here! All of our events are open to everyone; we want to help you explore your passion!"
+				openGraph={{
+					images: [
+						{
+							url: 'https://www.uclaacm.com/images/acm_committees.png',
+							width: 2506,
+							height: 979,
+							alt: 'The ACM at UCLA logo, surrounded by our eight committees: Studio, ICPC, Design, Cyber, Teach LA, W, AI, and Hack.',
+						},
+					],
+					site_name: 'ACM at UCLA',
+				}}
+			/>
 			<Banner decorative />
 			<Navigation committees={committees} />
 			<div className="committees-page-content">

--- a/pages/events.js
+++ b/pages/events.js
@@ -1,3 +1,4 @@
+import { NextSeo } from 'next-seo';
 import React from 'react';
 // import data from '../data/events';
 
@@ -9,6 +10,22 @@ import styles from '../styles/pages/Events.module.scss';
 function Events() {
 	return (
 		<Layout>
+			<NextSeo
+				title="Events | ACM at UCLA"
+				description="ACM is currently taking the summer off to
+				rest, recharge, and prepare for a hybrid fall quarter. As soon as we're back, this page is your one-stop shop for all the events we run. We'll see you soon!"
+				openGraph={{
+					images: [
+						{
+							url: 'https://www.uclaacm.com/images/logo.png',
+							width: 1200,
+							height: 1200,
+							alt: 'The ACM at UCLA logo',
+						},
+					],
+					site_name: 'ACM at UCLA',
+				}}
+			/>
 			<Banner decorative />
 			<div className={styles['events-container']}>
 				<h2>Our Events</h2>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,4 @@
+import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import React from 'react';
 
@@ -14,6 +15,21 @@ function Home () {
 	const { carousel, committees, news } = data;
 	return (
 		<Layout>
+			<NextSeo
+				title="Home | ACM at UCLA"
+				description="ACM at UCLA is UCLA's largest tech community, focused on making tech as accessible as possible. We're split up into an array of committees and initiatives that each focus on a specific area of computer science. Everyone is welcome to join - regardless of major, prior experience, or anything else!"
+				openGraph={{
+					images: [
+						{
+							url: 'https://www.uclaacm.com/images/logo.png',
+							width: 1200,
+							height: 1200,
+							alt: 'The ACM at UCLA logo',
+						},
+					],
+					site_name: 'ACM at UCLA',
+				}}
+			/>
 			<div className="home-page text-center">
 				<TGBanner />
 				<Banner />

--- a/pages/sponsors.js
+++ b/pages/sponsors.js
@@ -1,3 +1,4 @@
+import { NextSeo } from 'next-seo';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
@@ -13,6 +14,21 @@ function Sponsors() {
 	const { sponsors } = data;
 	return (
 		<Layout>
+			<NextSeo
+				title="Sponsors and Partners | ACM at UCLA"
+				description="ACM at UCLA couldn't happen without our amazing sponsors, partners, and affiliates that support all of our work. Interested in parterning with us? Send as an email at acm@ucla.edu!"
+				openGraph={{
+					images: [
+						{
+							url: 'https://www.uclaacm.com/images/logo.png',
+							width: 1200,
+							height: 1200,
+							alt: 'The ACM at UCLA logo',
+						},
+					],
+					site_name: 'ACM at UCLA',
+				}}
+			/>
 			<Banner decorative />
 			<div className="content-section text-center">
 				<h1>Our Sponsors</h1>

--- a/pages/techgala.js
+++ b/pages/techgala.js
@@ -1,3 +1,4 @@
+import { NextSeo } from 'next-seo';
 import React from 'react';
 
 import Banner from '../components/Banner';
@@ -10,6 +11,21 @@ function TechGala() {
 	const { tgprojects } = data;
 	return (
 		<Layout>
+			<NextSeo
+				title="Tech Gala | ACM at UCLA"
+				description="Tech Gala is ACM's annual showcase of the amazing projects that our student body has worked on. Learn more about the projects developed here, and keep your eyes out for the next Tech Gala!"
+				openGraph={{
+					images: [
+						{
+							url: 'https://www.uclaacm.com/images/techgala/techgala-banner-dark.png',
+							width: 1920,
+							height: 1005,
+							alt: 'The Tech Gala banner; features an isometric view of a lightbulb and stage props. Reads: "Thursday, February 11th 2021 at 6:30 PM PST on the ACM Discord"',
+						},
+					],
+					site_name: 'ACM at UCLA',
+				}}
+			/>
 			<div className='content'>
 				<Banner decorative/>
 				<div className="page-content">

--- a/pages/techgala.js
+++ b/pages/techgala.js
@@ -17,7 +17,7 @@ function TechGala() {
 				openGraph={{
 					images: [
 						{
-							url: 'https://www.uclaacm.com/images/techgala/techgala-banner-dark.png',
+							url: 'https://www.uclaacm.com/images/techgala/techgala-banner-dark.jpg',
 							width: 1920,
 							height: 1005,
 							alt: 'The Tech Gala banner; features an isometric view of a lightbulb and stage props. Reads: "Thursday, February 11th 2021 at 6:30 PM PST on the ACM Discord"',


### PR DESCRIPTION
This PR implements per-page SEO tags via [`next-seo`](https://github.com/garmeeh/next-seo). Under-the-hood, the package handles basic meta tags, and OpenGraph URLs; according to the documentation, Twitter now also parses OG data, and thus doesn't generate twitter-specific metadata.

I then manually write and apply copy for each page: the home page, about, committees, events, sponsors, and tech gala. We'll have to backport this to other new pages, like the ones introduced in #238 and #235. I chose not to add any default templating or abstract this to a component, since I think the copy differs enough where boilerplate doesn't help us too much.

For reviewers - it would be great if you could test this on a variety of social media platforms (Facebook, Twitter, Discord, Instagram. etc.). I've done Discord testing in the #test3 moderator channel of the server, as well as DMing myself on FB messenger.

Closes #116, (hopefully) closes #194.