### PR TITLE
resolves more axe errors

### DIFF
--- a/components/TechGala/ViewBanner.js
+++ b/components/TechGala/ViewBanner.js
@@ -4,7 +4,7 @@ import React from 'react';
 function TGBanner() {
     return (
         <div className="full-width blue">
-            <div id="sign-up-section" className="banner-section">
+            <div className="sign-up-section banner-section">
                 <div id="banner-left" className="half-width">
                     <h2 style={{fontSize: '1.6em'}}>Check out the projects from Tech Gala Winter &apos;21!</h2>
                 </div>

--- a/pages/events.js
+++ b/pages/events.js
@@ -28,7 +28,7 @@ function Events() {
 			/>
 			<Banner decorative />
 			<div className={styles['events-container']}>
-				<h2>Our Events</h2>
+				<h1>Our Events</h1>
 				<p>
 					We&apos;re taking the most of the summer off to
 					rest, recharge, and prepare for a hybrid fall quarter.

--- a/pages/index.js
+++ b/pages/index.js
@@ -56,11 +56,11 @@ function Home () {
 				<br /><br /><br />
 
 				<div className="blue">
-					<div id="sign-up-section" className="content-section">
-						<div id="sign-up-left" className="half-width">
+					<div className="sign-up-section content-section">
+						<div className="half-width">
 							<h2>Want to stay updated on what&rsquo;s going on?</h2>
 						</div>
-						<div id="sign-up-right" className="half-width">
+						<div className="sign-up-right half-width">
 							<Link href="http://eepurl.com/c5pE6P">
 								<a className="button tight dark" target="_blank" rel="noreferrer noopener">
 									Join our Mailing List

--- a/styles/pages/index.scss
+++ b/styles/pages/index.scss
@@ -49,11 +49,11 @@
   }
 }
 
-#sign-up-section {
+.sign-up-section {
   display: flex;
   flex-direction: row;
 
-  #sign-up-right {
+  .sign-up-right {
     align-items: center;
     display: flex;
     justify-content: center;
@@ -65,7 +65,7 @@
     width: 100%;
   }
 
-  #sign-up-section {
+  .sign-up-section {
     flex-direction: column;
     padding-bottom: 40px;
     text-align: center;


### PR DESCRIPTION
Now that #249, there are only a couple more axe errors on our radar to resolve. This PR takes the low-hanging fruit;

* we had used `#sign-up-section` in multiple different components that appeared on the same page. to resolve this in a low-impact manner, we shift the styling to use classes instead; we also remove an unstyled `#sign-up-left`
* the events page did not have a `<h1>` tag, so change the main header to use it!

There's a few remaining general issues with accessibility, namely the inaccessibility of our navigation - which is partially flagged by axe (the footer incorrectly uses headers). I'll resolve this in #236!

related to (but does not close): #247.