### PR TITLE
Town Hall follow-up: redirect, footer, and SEO

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,2 @@
 /fallgm         /gm/f21
+/town-hall      /town-hall/f21

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -13,6 +13,7 @@ const footerACMLinks = [
 	{ title: 'Dev Team', path: '/dev'},
 	{ title: 'Sponsors', path: '/sponsors' },
 	{ title: 'Tech Gala', path: '/techgala' },
+	{ title: 'CS Town Hall', path: '/town-hall/f21' },
 	{ title: 'Membership Portal', path: 'https://members.uclaacm.com', ext: true },
 	{ title: 'COVID-19', path: '/covid' },
 ];

--- a/pages/town-hall/f21.js
+++ b/pages/town-hall/f21.js
@@ -26,14 +26,14 @@ function TownHall() {
 		<Layout>
 			<NextSeo
 				title="Fall 2021 Computer Science Town Hall | ACM at UCLA"
-				description="Town hall!"
+				description="Ask questions and get your voice heard at the Fall 2021 Computer Science Town Hall! Wednesday, November 10th from 6:30 - 8:30 PM PT - we hope to see you there :)"
 				openGraph={{
 					images: [
 						{
-							url: 'https://www.uclaacm.com/images/logo.png',
-							width: 1200,
-							height: 1200,
-							alt: 'The ACM at UCLA logo',
+							url: 'https://www.uclaacm.com/images/town-hall/town-hall-banner-f21.png',
+							width: 1920,
+							height: 1005,
+							alt: 'A banner that reads "Fall 2021 Computer Science Town Hall: ask questions and get your voice heard! Wednesday, November 10 from 6:30 - 8:30 PM PT. Held at the Mong Auditorium and Online; visit uclaacm.com/town-hall for more information. Co-hosted by ACM at UCLA, UPE at UCLA, exploretech.la, and the UCLA Computer Science Department."',
 						},
 					],
 					site_name: 'ACM at UCLA',
@@ -42,7 +42,7 @@ function TownHall() {
 			<Banner decorative />
 			<div className="content-container-tight">
         <div className="text-center">
-          <Image src={TownHallBanner} alt="A banner that reads 'Fall 2021 Computer Science Town Hall: ask questions and get your voice heard! Wednesday, November 10 from 6:30 - 8:30 PM PT. Held at the Mong Auditorium and Online; visit uclaacm.com/town-hall for more information. Co-hosted by ACM at UCLA, UPE at UCLA, exploretech.la, and the UCLA Computer Science Department." />
+          <Image src={TownHallBanner} alt="A banner that reads 'Fall 2021 Computer Science Town Hall: ask questions and get your voice heard! Wednesday, November 10 from 6:30 - 8:30 PM PT. Held at the Mong Auditorium and Online; visit uclaacm.com/town-hall for more information. Co-hosted by ACM at UCLA, UPE at UCLA, exploretech.la, and the UCLA Computer Science Department.'" />
           <h1>Fall 2021 Computer Science Town Hall</h1>
         </div>
         <p>


### PR DESCRIPTION
This wraps up #324 (related to #321) by:

* adding a Netlify redirect from `/town-hall` to `/town-hall/f21`
* adding a link in the footer
* filling out the SEO stuff, now that the image has been deployed to prod in #324