### PR TITLE
Fixes navbar bug of showing Initiatives, Jedi and Impact on desktop

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -45,8 +45,8 @@ export default function Navbar() {
                   <li><ActiveLink activeClassName="active" href="/committees#hack" passHref={true}><button type="button" onClick={menuActivate}>Hack</button></ActiveLink></li>
                 </ul>
               </li>
-              <li>initiatives</li>
-              <li id="initiatives-mobile-nav-item">
+              <li className="hide-on-desktop">initiatives</li>
+              <li className="hide-on-desktop" id="initiatives-mobile-nav-item">
                 <ul className="committee-mobile-nav" role="presentation">
                   <li><ActiveLink activeClassName="active" act href="/jedi" passHref={true}><button type="button" onClick={menuActivate}>JEDI</button></ActiveLink></li>
                   <li><ActiveLink activeClassName="active" href="/impact" passHref={true}><button type="button" onClick={menuActivate}>impact</button></ActiveLink></li>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -52,6 +52,10 @@ h3 {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
   }
+  
+  .hide-on-desktop {
+    display: none;
+  }
 }
 
 @media (min-width: $tablet-breakpoint) {


### PR DESCRIPTION
creates CSS class `hide-on-desktop` and adds to `globals.scss`

this makes display none when screen size is bigger than the navbar breakpoint
this class is added to the initiatives section so it doesn't show up on desktop navbar