### PR TITLE
Add countdown element

### DIFF
--- a/components/CountdownElement.js
+++ b/components/CountdownElement.js
@@ -3,8 +3,8 @@ import Countdown from 'react-countdown';
 
 export default function CountdownElement(props) {
     const chooseWhatToRender = ({ completed }) => {
-        if (completed) { 
-            return <>{props.children}</>; 
+        if (completed) {
+            return <>{props.children}</>;
         }
         else {
             return <>{props.fallback}</>;

--- a/components/CountdownElement.js
+++ b/components/CountdownElement.js
@@ -2,6 +2,10 @@ import React from 'react';
 import Countdown from 'react-countdown';
 
 export default function CountdownElement(props) {
+    // Input two props, switchTime and fallback
+    // To prevent timezone issues switchTime is a JS timestamp, to create a timestamp can use "+ new Date(...)"
+    // fallback is rendered if the time passes switchTime
+
     const chooseWhatToRender = ({ completed }) => {
         if (completed) {
             return <>{props.children}</>;

--- a/components/CountdownElement.js
+++ b/components/CountdownElement.js
@@ -12,6 +12,6 @@ export default function CountdownElement(props) {
     };
 
     return (
-        <Countdown date={props.switchTime} renderer={chooseWhatToRender} />
+        <Countdown date={new Date(props.switchTime)} renderer={chooseWhatToRender} />
 	);
 }

--- a/components/CountdownElement.js
+++ b/components/CountdownElement.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Countdown from 'react-countdown';
+
+export default function CountdownElement(props) {
+    const chooseWhatToRender = ({ completed }) => {
+        if (completed) { 
+            return <>{props.children}</>; 
+        }
+        else {
+            return <>{props.fallback}</>;
+        }
+    };
+
+    return (
+        <Countdown date={props.switchTime} renderer={chooseWhatToRender} />
+	);
+}

--- a/pages/town-hall/f21.js
+++ b/pages/town-hall/f21.js
@@ -19,7 +19,7 @@ const inlineButtonListStyle = {
   marginBottom: '0.5em',
 };
 
-const TEST_START_TIME = new Date(`2021-11-29T01:10:00-08:00`);
+const TEST_START_TIME = new Date('2021-11-29T01:10:00-08:00');
 
 function TownHall() {
   const embed2021WRef = useRef(null);

--- a/pages/town-hall/f21.js
+++ b/pages/town-hall/f21.js
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import React, { useRef } from 'react';
 
 import Banner from '../../components/Banner';
+import CountdownElement from '../../components/CountdownElement';
 import Layout from '../../components/Layout';
 
 import TestimonialsCourseChanges from '../../public/images/town-hall/testimonials-course-changes.png';
@@ -18,11 +19,14 @@ const inlineButtonListStyle = {
   marginBottom: '0.5em',
 };
 
+const TEST_START_TIME = new Date(`2021-11-29T01:10:00-08:00`);
+
 function TownHall() {
   const embed2021WRef = useRef(null);
   // note: this does not work :( prob need useEffect + useState!
   const embedWidth = embed2021WRef.current ? embed2021WRef.current.offsetWidth : 500;
 	return (
+    <CountdownElement switchTime={TEST_START_TIME} fallback={<span>come back soon :)</span>}>
 		<Layout>
 			<NextSeo
 				title="Fall 2021 Computer Science Town Hall | ACM at UCLA"
@@ -141,6 +145,7 @@ function TownHall() {
         </div>
 			</div>
 		</Layout>
+    </CountdownElement>
 	);
 }
 

--- a/pages/town-hall/f21.js
+++ b/pages/town-hall/f21.js
@@ -19,14 +19,14 @@ const inlineButtonListStyle = {
   marginBottom: '0.5em',
 };
 
-const TEST_START_TIME = new Date('2021-11-29T01:10:00-08:00');
+const TEST_START_TIMESTAMP = + new Date('2021-11-29T21:07:00-08:00');
 
 function TownHall() {
   const embed2021WRef = useRef(null);
   // note: this does not work :( prob need useEffect + useState!
   const embedWidth = embed2021WRef.current ? embed2021WRef.current.offsetWidth : 500;
 	return (
-    <CountdownElement switchTime={TEST_START_TIME} fallback={<span>come back soon :)</span>}>
+    <CountdownElement switchTime={TEST_START_TIMESTAMP} fallback={<span>come back soon :)</span>}>
 		<Layout>
 			<NextSeo
 				title="Fall 2021 Computer Science Town Hall | ACM at UCLA"


### PR DESCRIPTION
Add countdown element to address issue #339. Also added the component to the old town hall page to test it. Takes in a prop for the time when the countdown ends as a Javascript timestamp (number of milliseconds from 1 January 1970 00:00:00 UTC, what you get from using valueOf for a Date), and a fallback component to render. When the time passes, the element switches from rendering the fallback component to its children components. Using the Javascript timestamp makes it resistant to timezone issues.