### PR TITLE
Fixes to event generation script

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -51,9 +51,17 @@ const generateSingleEvent = ({
     end = moment(`${date} ${endHr} PM`, 'YYYY-MM-DD LT').valueOf();
   }
 
-  // add if location contains ucla.zoom.us, change location to "zoom" and links to have the zoom link
-  if (!links) {
-    links = [];
+  if(location.includes('ucla.zoom.us')) {
+    let zoomLink = location;
+    location = 'Zoom';
+    if(!links){
+      links = [];
+    }
+    links.push({
+      text: 'Zoom Link',
+      href: zoomLink,
+      ext: true,
+    });
     if (fblink) {
       links.push({
         text: 'Facebook Event',

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -55,7 +55,7 @@ const generateSingleEvent = ({
     links = [];
   }
   if(location.includes('ucla.zoom.us')) {
-    let zoomLink = location;
+    const zoomLink = location;
     location = 'Zoom';
     links.push({
       text: 'Zoom Link',

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -62,13 +62,16 @@ const generateSingleEvent = ({
       href: zoomLink,
       ext: true,
     });
-    if (fblink) {
-      links.push({
-        text: 'Facebook Event',
-        href: fblink,
-        ext: true,
-      });
+  }
+  if (fblink) {
+    if(!links){
+      links = [];
     }
+    links.push({
+      text: 'Facebook Event',
+      href: fblink,
+      ext: true,
+    });
   }
 
   return {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 const getCssStringFromCommittee = (committee) => {
-  switch (committee) {
+  switch (committee.trim()) {
     case 'General':
     case 'Impact': // we should change the branding here soon
       return 'board';

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -51,12 +51,12 @@ const generateSingleEvent = ({
     end = moment(`${date} ${endHr} PM`, 'YYYY-MM-DD LT').valueOf();
   }
 
+  if(!links){
+    links = [];
+  }
   if(location.includes('ucla.zoom.us')) {
     let zoomLink = location;
     location = 'Zoom';
-    if(!links){
-      links = [];
-    }
     links.push({
       text: 'Zoom Link',
       href: zoomLink,
@@ -64,9 +64,6 @@ const generateSingleEvent = ({
     });
   }
   if (fblink) {
-    if(!links){
-      links = [];
-    }
     links.push({
       text: 'Facebook Event',
       href: fblink,

--- a/scripts/recurring-event-generator.mjs
+++ b/scripts/recurring-event-generator.mjs
@@ -13,7 +13,7 @@ const results = [];
 let offset = 20;
 
 fs.createReadStream(fname)
-  .pipe(csv())
+  .pipe(csv({skipLines:'1'}))
   .on('data', (data) => {
     if (data.Committee.includes('Example')) {
       return;

--- a/scripts/single-event-generator.mjs
+++ b/scripts/single-event-generator.mjs
@@ -13,7 +13,7 @@ const results = [];
 const offset = 100;
 
 fs.createReadStream(fname)
-  .pipe(csv())
+  .pipe(csv({skipLines:'1'}))
   .on('data', (data) => {
     if (data.Committee.includes('Example')) {
       return;


### PR DESCRIPTION
As of now
- changes location to zoom and adds zoom link if event is occuring on zoom (checks for `ucla.zoom.us`)
- removes first line of CSV file so you don't have to manually remove when saving
- removes whitespaces before and after committee names when mapping

Going to leave a lot of other problems with this page to try and deal with them during the one click event publishing project, especially the ones regarding hardcoding - since I'd like to include the events page to be one of the targets of publishing!

(sorry for the unnecessary commits, kinda confused myself on the links logic)