### PR TITLE
makes carousel decorative

### DIFF
--- a/components/Carousel.js
+++ b/components/Carousel.js
@@ -22,9 +22,10 @@ export default class Carousel extends React.Component {
 					<a
 						href={item} target="_blank"
 						rel="noreferrer noopener"
-						key={i}>
-							{/* TODO: somehow encode alt tags here! */}
-							<Image src={item} width={IMAGE_WIDTH} height={IMAGE_WIDTH} alt="decorative carousel image" />
+						key={i}
+						tabIndex="-1"
+						>
+							<Image src={item} width={IMAGE_WIDTH} height={IMAGE_WIDTH} alt="" />
 					</a>),
 			});
 		}

--- a/pages/index.js
+++ b/pages/index.js
@@ -73,7 +73,7 @@ function Home () {
 						</div>
 					</div>
 				</div>
-				<Carousel images={carousel.images} />
+				<Carousel images={carousel.images} aria-hidden="true"/>
 			</div>
 		</Layout>
 	);


### PR DESCRIPTION
makes carousel images non-tabbable/selectable
sets `alt=""` to mark as decorative
makes carousel aria-hidden

closes #273 