### PR TITLE
changes events page `.filter` z-index to 9

### DIFF
--- a/styles/components/Events/Filters.module.scss
+++ b/styles/components/Events/Filters.module.scss
@@ -3,7 +3,7 @@
 .filter {
   padding-bottom: 2.5rem;
   position: relative;
-  z-index: 99;
+  z-index: 9;
   @media screen and (min-width: $tablet-breakpoint) {
     max-width: calc(75rem - 300px - 2rem - 3em) !important;
     width: calc(100vw - 300px - 2rem - 3em) !important;


### PR DESCRIPTION
This is a bugfix for something that has been bothering me: the search bar/filter dropdown on the events page is "on top" of the navbar:

![Screen Shot 2022-03-23 at 1 04 27 PM](https://user-images.githubusercontent.com/14893287/159786184-7eb5794c-8676-4e22-ad88-d6363a06232c.png)
![Screen Shot 2022-03-23 at 1 04 37 PM](https://user-images.githubusercontent.com/14893287/159786188-aca3344a-12a0-4fe6-ba4c-e0f8187d010f.png)

This PR lowers the z-index on `.filter` to `9`, so it's less than the navbar (which is `10`).


![Screen Shot 2022-03-23 at 1 05 19 PM](https://user-images.githubusercontent.com/14893287/159786288-fb715711-9bfe-4c76-8b07-bfc68ea6cb37.png)

