### PR TITLE
Fixed stretched images

### DIFF
--- a/components/NewsArticle.js
+++ b/components/NewsArticle.js
@@ -12,6 +12,7 @@ function Article(props) {
 					src={props.article.image}
 					width={360}
 					height={200}
+					objectFit='cover'
 					alt={props.article.alt}
 				/>
 				<h3>{props.article.headline}</h3>


### PR DESCRIPTION
Images in the News section were stretched. I fixed that by setting `objectFit` to `cover` in the `Image` component.