### PR TITLE
tests: adds aXe test for `<Officers />`; resolves `key` bug

### DIFF
--- a/__tests__/components/LeadershipOfficers.test.js
+++ b/__tests__/components/LeadershipOfficers.test.js
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import Officers from '../../components/LeadershipOfficers';
+import data from '../../data';
+
+expect.extend(toHaveNoViolations);
+
+// TODO: consider lifting this mock globally
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img alt={props.alt} {...props} />;
+  },
+}));
+
+it('has no axe violations', async () => {
+  const { leadership } = data;
+
+  // this let / async construct is required since next/image rendering
+  // is a side effect that needs to be captured with async act
+  // see https://reactjs.org/docs/test-utils.html#act
+  let results;
+  await act(async () => {
+    const { container } = render(<Officers officers={leadership} />);
+    results = await axe(container);
+  });
+
+  expect(results).toHaveNoViolations();
+});

--- a/components/LeadershipOfficers.js
+++ b/components/LeadershipOfficers.js
@@ -27,7 +27,7 @@ function Officers(props){
 		<div className="grid-desktop-3">
 			{
 				props.officers.map(
-					officer => <Officer officer={officer} key={officer.image} />,
+					officer => <Officer officer={officer} key={officer.name + officer.position} />,
 				)
 			}
 		</div>


### PR DESCRIPTION
Followup to #412, gradually increasing coverage.

Two small notes:

1. You need to mock `next/image` somehow. This trivial mock is from https://github.com/vercel/next.js/discussions/18516, however I think after you upgrade to Next 12 it becomes easier.
2. There's a current bug in `Officers` that incorrectly uses a non-existent field as the `key`. Updated to use an existing field.