### PR TITLE
Fix error on events calendar week view

### DIFF
--- a/pages/events.js
+++ b/pages/events.js
@@ -62,8 +62,8 @@ function Events({ events }) {
 						<Calendar
 							localizer={localizer}
 							events={indexedEvents}
-							startAccessor="start"
-							endAccessor="end"
+							startAccessor={(event) => new Date(event.start)}
+							endAccessor={(event) => new Date(event.end)}
 							className={styles['calendar-size-controller']}
 							onSelectEvent={setActiveEvent}
 							eventPropGetter={getEventClassByEvent}


### PR DESCRIPTION
# Bug
Clicking on the week view in the events calendar throws an error.
<img width="1241" alt="Screen Shot 2023-01-20 at 12 46 05 PM" src="https://user-images.githubusercontent.com/39035908/213802121-c9f92119-6063-4e30-b27e-fb1c23bd2d7b.png">

# Fix
Revert two lines from #563.
I initially thought the `new Date()` instantiation wasn't necessary. Turns out it's only used in non-month calendar views oops.

# Test
1) `yarn start`
2) go to `localhost:3000/events` 
3) Click on week view, month view, and agenda; Check that events appear as expected.
<img width="1202" alt="Screen Shot 2023-01-20 at 1 01 25 PM" src="https://user-images.githubusercontent.com/39035908/213804483-ee70615c-ca97-482b-b974-40420c0501bb.png">