### PR TITLE
fix: ACM Studio `Gam Jams` typo :D

### DIFF
--- a/data/committees.js
+++ b/data/committees.js
@@ -61,7 +61,7 @@ export default [
 				),
 			},
 			{
-				title: 'Gam Jams',
+				title: 'Game Jams',
 				image: {
 					src: '',
 					alt: '',


### PR DESCRIPTION
Addressed the typo with `Gam Jams` :D.