### PR TITLE
Fix duplicate events on calendar

### DIFF
--- a/scripts/event-generator-sheets.mjs
+++ b/scripts/event-generator-sheets.mjs
@@ -38,7 +38,9 @@ async function getAllEvents() {
   for (let i = 1; i <= 10; i++) {
     events = events.concat(getRecurringEventsOfWeek(recurring_rows, i));
   }
-  return events;
+  return events.filter((item, index, self) => index === self.findIndex(
+      (other) => item.title === other.title && item.rawStart === other.rawStart),
+    );
 }
 
 // Read single events of Week n


### PR DESCRIPTION
# Bug
Events announced multiple times through the newsletter show up multiple times on the website events calendar
![image](https://github.com/uclaacm/website/assets/39035908/4d9da801-319c-433d-b84c-4e685bdaa494)


# Fix
Filter out events with the same title and start time
<img width="888" alt="Screen Shot 2023-06-01 at 6 44 40 PM" src="https://github.com/uclaacm/website/assets/39035908/3bca1bb4-8a89-4d47-a7a5-91cd3d110555">
