### PR TITLE
Modularize Town Hall Page

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,16 +22,24 @@ jobs:
       matrix:
         node-version: [16.x]
 
+    env:
+      EVENTS_SPREADSHEET_ID: ${{ secrets.EVENTS_SPREADSHEET_ID }}
+      SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
+      DIRECTORY_SPREADSHEET_ID: ${{ secrets.DIRECTORY_SPREADSHEET_ID }}
+      TOWNHALL_SPREADSHEET_ID: ${{ secrets.TOWNHALL_SPREADSHEET_ID }}
+
     steps:
     - uses: actions/checkout@v2
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+
     - run: npm install
+
     - run: npm run ofp
-      env:
-        EVENTS_SPREADSHEET_ID: ${{ secrets.EVENTS_SPREADSHEET_ID }}
-        SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
-        DIRECTORY_SPREADSHEET_ID: ${{ secrets.DIRECTORY_SPREADSHEET_ID }}
+    
+    - run: npm run thp
+
     - run: npm run lint

--- a/.github/workflows/node-build.yml
+++ b/.github/workflows/node-build.yml
@@ -22,23 +22,28 @@ jobs:
       matrix:
         node-version: [16.x]
 
+    env:
+      EVENTS_SPREADSHEET_ID: ${{ secrets.EVENTS_SPREADSHEET_ID }}
+      SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
+      DIRECTORY_SPREADSHEET_ID: ${{ secrets.DIRECTORY_SPREADSHEET_ID }}
+      TOWNHALL_SPREADSHEET_ID: ${{ secrets.TOWNHALL_SPREADSHEET_ID }}
+
     steps:
     - uses: actions/checkout@v2
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+
     - run: npm install
+
     - run: npm run ofp
-      env:
-        EVENTS_SPREADSHEET_ID: ${{ secrets.EVENTS_SPREADSHEET_ID }}
-        SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
-        DIRECTORY_SPREADSHEET_ID: ${{ secrets.DIRECTORY_SPREADSHEET_ID }}
+
+    - run: npm run thp
+
     - run: npm run build
-      env:
-        EVENTS_SPREADSHEET_ID: ${{ secrets.EVENTS_SPREADSHEET_ID }}
-        SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
-        DIRECTORY_SPREADSHEET_ID: ${{ secrets.DIRECTORY_SPREADSHEET_ID }}
+
     - run: npm test
       env:
         CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 *.csv
 output.json
 offoutput.json
+townhall.json

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 output.json
 offoutput.json
 townhall.json
+past-townhall.json

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,2 @@
 /fallgm         /gm/f22
-/town-hall      /town-hall/s22
 /wintergm       /gm/w22

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -8,7 +8,7 @@ const footerACMLinks = [
 	{ title: 'About', path: '/about' },
 	{ title: 'Events', path: '/events' },
 	{ title: 'General Meeting', path: '/gm/w24' },
-	{ title: 'CS Town Hall', path: '/town-hall/f23' },
+	{ title: 'CS Town Hall', path: '/town-hall' },
 	{ title: 'Internship Program', path: '/internship' },
 	{ title: 'Dev Team', path: '/dev'},
 	{ title: 'Sponsors', path: '/sponsors' },

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run ofp; npm run build"
+  command = "npm run ofp; npm run thp; npm run build"
   publish = "build"
 
 [[plugins]]

--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,7 @@ module.exports = {
       'jcfp.site',
       'photos.google.com',
       'photos.app.goo.gl',
+      'www.uclaacm.com',
     ],
   },
   target: 'serverless',

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "next dev",
     "start-production": "next start",
-    "build": "node scripts/officer-parser.mjs && node scripts/town-hall-generator.mjs && next build",
+    "build": "npm run ofp && npm run thp && next build",
     "lint-js": "eslint \"**/*.js\"",
     "lint-js-fix": "eslint --fix \"**/*.js\"",
     "lint-css": "stylelint \"**/*.css\" \"**/*.scss\"",
@@ -34,6 +34,7 @@
     "reg": "node scripts/recurring-event-generator.mjs",
     "seg": "node scripts/single-event-generator.mjs",
     "ofp": "node scripts/officer-parser.mjs",
+    "thp": "node scripts/town-hall-generator.mjs",
     "test": "jest --env=jsdom"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "next dev",
     "start-production": "next start",
-    "build": "node scripts/officer-parser.mjs && scripts/town-hall-generator.mjs && next build",
+    "build": "node scripts/officer-parser.mjs && node scripts/town-hall-generator.mjs && next build",
     "lint-js": "eslint \"**/*.js\"",
     "lint-js-fix": "eslint --fix \"**/*.js\"",
     "lint-css": "stylelint \"**/*.css\" \"**/*.scss\"",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "next dev",
     "start-production": "next start",
-    "build": "node scripts/officer-parser.mjs && next build",
+    "build": "node scripts/officer-parser.mjs && scripts/town-hall-generator.mjs && next build",
     "lint-js": "eslint \"**/*.js\"",
     "lint-js-fix": "eslint --fix \"**/*.js\"",
     "lint-css": "stylelint \"**/*.css\" \"**/*.scss\"",

--- a/pages/town-hall.js
+++ b/pages/town-hall.js
@@ -5,12 +5,12 @@ import Image from 'next/image';
 import Link from 'next/link';
 import React, { useRef } from 'react';
 
-import Banner from '../../components/Banner';
-import Layout from '../../components/Layout';
+import Banner from '../components/Banner';
+import Layout from '../components/Layout';
 
-import pastData from '../../past-townhall.json';
-import TestimonialsCourseChanges from '../../public/images/town-hall/testimonials-course-changes.png';
-import data from '../../townhall.json';
+import pastData from '../past-townhall.json';
+import TestimonialsCourseChanges from '../public/images/town-hall/testimonials-course-changes.png';
+import data from '../townhall.json';
 
 const TOWN_HALL_2021_WINTER_VIDEO = 'https://www.youtube.com/embed/Eq2xsShPMVc';
 

--- a/pages/town-hall.js
+++ b/pages/town-hall.js
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { NextSeo } from 'next-seo';
 import Image from 'next/image';
 import Link from 'next/link';
-import React, { useRef } from 'react';
+import React from 'react';
 
 import Banner from '../components/Banner';
 import Layout from '../components/Layout';
@@ -16,14 +16,36 @@ const TOWN_HALL_2021_WINTER_VIDEO = 'https://www.youtube.com/embed/Eq2xsShPMVc';
 
 const inlineButtonListStyle = {
   display: 'inline-block',
-  marginBottom: '0.5em',
+  marginBottom: '1em',
+};
+
+const TBD = {
+  fontSize: '2em',
+  fontWeight: 'bold',
+  textAlign: 'center',
+};
+
+const video_wrapper = {
+  position: 'relative',
+  width: '100%',
+  height: '0',
+  overflow: 'hidden',
+  paddingTop: '56.25%',
+  marginBottom: '2rem',
+};
+
+const video = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
 };
 
 function TownHall() {
-  const embed2021WRef = useRef(null);
-  const embedWidth = embed2021WRef.current ? embed2021WRef.current.offsetWidth : 500;
 
   let townHall = {
+    status: true,
     title: '[Title]',
     description: '',
     alt_text: '',
@@ -43,32 +65,37 @@ function TownHall() {
   // Fetch and assign data from townhall.json
   for(let row of data) {
     switch(row.name) {
+      case 'Event Status':
+        // Set event status to true or false
+        (row.description == 'TBD' || row.description == 'Canceled') ?
+          townHall.status = false : townHall.status = true;
+        break;
       case 'Title':
-        if(row.description) { townHall.title = row.description; }
+        if (row.description) { townHall.title = row.description; }
         break;
       case 'Banner':
-        if(row.description) { townHall.image = row.description; }
+        if (row.description) { townHall.image = row.description; }
         break;
       case 'Time':
-        if(row.description) { townHall.time = row.description; }
+        if (row.description) { townHall.time = row.description; }
         break;
       case 'Date':
-        if(row.description) { townHall.date = row.description; }
+        if (row.description) { townHall.date = row.description; }
         break;
       case 'Location':
-        if(row.description) { townHall.location = row.description; }
+        if (row.description) { townHall.location = row.description; }
         break;
       case 'Quarter':
-        if(row.description) { townHall.quarter = row.description; }
+        if (row.description) { townHall.quarter = row.description; }
         break;
       case 'Week':
-        if(row.description) { townHall.week = row.description; }
+        if (row.description) { townHall.week = row.description; }
         break;
       case 'RSVP Form':
-        if(row.description) { townHall.rsvp = row.description; }
+        if (row.description) { townHall.rsvp = row.description; }
         break;
       case 'Survey Form':
-        if(row.description) { townHall.survey = row.description; }
+        if (row.description) { townHall.survey = row.description; }
         break;
     }
   }
@@ -84,7 +111,7 @@ function TownHall() {
       <NextSeo
         title={townHall.title + ' | ACM at UCLA'}
         description={townHall.description}
-        openGraph={{
+        openGraph={townHall.status ? {
           images: [
             {
               url: townHall.image,
@@ -94,18 +121,23 @@ function TownHall() {
             },
           ],
           site_name: 'ACM at UCLA',
-        }}
+        } : undefined}
       />
       {/* Most Recent Town Hall*/}
       <Banner decorative />
       <div className="content-container-tight">
         <div className="text-center">
-          <Image
-            src={townHall.image}
-            alt={townHall.alt_text}
-            width={1920}
-            height={1005}
-          />
+          {townHall.status ?
+            <Image
+              src={townHall.image}
+              alt={townHall.alt_text}
+              width={1920}
+              height={1005}
+              priority={true}
+            />
+            :
+            <></>
+          }
           <h1>{townHall.title}</h1>
         </div>
         <p>
@@ -113,12 +145,18 @@ function TownHall() {
           opportunity for students to directly speak with professors and
           administrators in the CS department.
         </p>
-        <p>
-          The {townHall.quarter} Town Hall will take place on <b>{townHall.date}</b> (Week {townHall.week})
-          at <b>{townHall.time} PT</b> in the {townHall.location}.
-        </p>
-              {/* eslint-disable-next-line max-len */}
-              {/* <p>While the event was not recorded, you are welcome to read the survey form summaries and slides as well as the meeting notes.</p> */}
+
+        {townHall.status ?
+          <p>
+            The {townHall.quarter} Town Hall will take place on <b>{townHall.date}</b> (Week {townHall.week})
+            at <b>{townHall.time} PT</b> in the {townHall.location}.
+          </p>
+          :
+          <p style={TBD}>TBD</p>
+        }
+
+        {/* eslint-disable-next-line max-len */}
+        {/* <p>While the event was not recorded, you are welcome to read the survey form summaries and slides as well as the meeting notes.</p> */}
         <p>
           In past years, the Town Hall has been a huge driver of student
           feedback and improvements to curriculum; this includes:
@@ -168,16 +206,18 @@ function TownHall() {
               We need to hear your voice! Please answer this survey before the
               event.
             </p>
-            <Link href={townHall.survey}>
-              <a className="button" target="_blank" rel="noopener noreferrer">
-                <FontAwesomeIcon
-                  icon={faFileAlt}
-                  fixedWidth
-                  aria-hidden={true}
-                />{' '}
-                CS Town Hall Survey
-              </a>
-            </Link>
+            <li style={inlineButtonListStyle}>
+              <Link href={townHall.survey}>
+                <a className="button" target="_blank" rel="noopener noreferrer">
+                  <FontAwesomeIcon
+                    icon={faFileAlt}
+                    fixedWidth
+                    aria-hidden={true}
+                  />{' '}
+                  CS Town Hall Survey
+                </a>
+              </Link>
+            </li>
           </div>
           <div>
             <Image
@@ -235,14 +275,14 @@ function TownHall() {
               <Image
                 src={pastTownHall.banner}
                 alt={pastTownHall.alt_text}
-                width={embedWidth}
-                height={(embedWidth * 315) / 560}
-                layout="fixed"
+                width={800}
+                height={450}
+                quality={70}
               />
             </div>
           </div>
         ))}
-
+        {/* Winter 2021 Town Hall (Static) */}
         <div className="grid-tablet-2">
           <div>
             <h3>Winter 2021 // Wednesday, February 24th 2021</h3>
@@ -287,10 +327,11 @@ function TownHall() {
               </li>
             </ul>
           </div>
-          <div ref={embed2021WRef}>
+          <div style={video_wrapper}>
             <iframe
-              width={embedWidth}
-              height={(embedWidth * 315) / 560}
+              style={video}
+              width={600}
+              height={338}
               src={TOWN_HALL_2021_WINTER_VIDEO}
               title="YouTube video player"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"

--- a/pages/town-hall.js
+++ b/pages/town-hall.js
@@ -46,6 +46,7 @@ function TownHall() {
 
   let townHall = {
     status: true,
+    status_text: '',
     title: '[Title]',
     description: '',
     alt_text: '',
@@ -69,6 +70,7 @@ function TownHall() {
         // Set event status to true or false
         (row.description == 'TBD' || row.description == 'Canceled') ?
           townHall.status = false : townHall.status = true;
+        townHall.status_text = row.description;
         break;
       case 'Title':
         if (row.description) { townHall.title = row.description; }
@@ -152,7 +154,7 @@ function TownHall() {
             at <b>{townHall.time} PT</b> in the {townHall.location}.
           </p>
           :
-          <p style={TBD}>TBD</p>
+          <p style={TBD}>{townHall.status_text}</p>
         }
 
         {/* eslint-disable-next-line max-len */}

--- a/pages/town-hall/town-hall.js
+++ b/pages/town-hall/town-hall.js
@@ -1,0 +1,412 @@
+import { faFileAlt } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { NextSeo } from 'next-seo';
+import Image from 'next/image';
+import Link from 'next/link';
+import React, { useRef } from 'react';
+
+import Banner from '../../components/Banner';
+import Layout from '../../components/Layout';
+
+import SpringTownhallImage from '../../public/images/spring-2022-townhall-photo.JPG';
+import TestimonialsCourseChanges from '../../public/images/town-hall/testimonials-course-changes.png';
+import TownHallFall2021Attending from '../../public/images/town-hall/town-hall-attending-f21.jpeg';
+import F22TownHallBanner from '../../public/images/town-hall/town-hall-banner-f22.png';
+import data from '../../townhall.json';
+
+const TOWN_HALL_2021_WINTER_VIDEO = 'https://www.youtube.com/embed/Eq2xsShPMVc';
+
+const inlineButtonListStyle = {
+  display: 'inline-block',
+  marginBottom: '0.5em',
+};
+
+function TownHall() {
+  const embed2021WRef = useRef(null);
+  const embedWidth = embed2021WRef.current ? embed2021WRef.current.offsetWidth : 500;
+
+  let townHall = {
+    title: '[Title]',
+    description: '',
+    alt_text: '',
+    image: '',
+    time: '[Time]',
+    date: '[Date]',
+    location: '[Location]',
+    quarter: '[Quarter]',
+    week: '[Week #]',
+    rsvp: '',
+    survey: '',
+  };
+
+  // Fetch and assign data from townhall.json
+  for(let row of data) {
+    switch(row.name) {
+      case 'Title':
+        if(row.description) { townHall.title = row.description; }
+        break;
+      case 'Banner':
+        if(row.description) { townHall.image = row.description; }
+        break;
+      case 'Time':
+        if(row.description) { townHall.time = row.description; }
+        break;
+      case 'Date':
+        if(row.description) { townHall.date = row.description; }
+        break;
+      case 'Location':
+        if(row.description) { townHall.location = row.description; }
+        break;
+      case 'Quarter':
+        if(row.description) { townHall.quarter = row.description; }
+        break;
+      case 'Week':
+        if(row.description) { townHall.week = row.description; }
+        break;
+      case 'RSVP Form':
+        if(row.description) { townHall.rsvp = row.description; }
+        break;
+      case 'Survey Form':
+        if(row.description) { townHall.survey = row.description; }
+        break;
+    }
+  }
+
+  // Set alt text for SEO
+  townHall.alt_text = "A banner that reads '" + townHall.title + ': ask questions and be heard! ' + townHall.date + ' from ' + townHall.time + ' PT. ' + townHall.location + ". Ask Questions and get your voice heard!'";
+
+  // Set description for SEO
+  townHall.description = 'Ask questions and get your voice heard at the ' + townHall.title + '! ' + townHall.date + ' from ' + townHall.time + ' PT - we hope to see you there :)';
+
+  return (
+    <Layout>
+      <NextSeo
+        title={townHall.title + ' | ACM at UCLA'}
+        description={townHall.description}
+        openGraph={{
+          images: [
+            {
+              url: townHall.image,
+              alt: townHall.alt_text,
+              width: 1920,
+              height: 1005,
+            },
+          ],
+          site_name: 'ACM at UCLA',
+        }}
+      />
+      <Banner decorative />
+      <div className="content-container-tight">
+        <div className="text-center">
+          <Image
+            src={townHall.image}
+            alt={townHall.alt_text}
+            width={1920}
+            height={1005}
+          />
+          <h1>{townHall.title}</h1>
+        </div>
+        <p>
+          <b>Ask questions and be heard!</b> The CS Town Hall is an
+          opportunity for students to directly speak with professors and
+          administrators in the CS department.
+        </p>
+        <p>
+          The {townHall.quarter} Town Hall will take place on <b>{townHall.date}</b> (Week {townHall.week})
+          at <b>{townHall.time} PT</b> in the {townHall.location}.
+        </p>
+              {/* eslint-disable-next-line max-len */}
+              {/* <p>While the event was not recorded, you are welcome to read the survey form summaries and slides as well as the meeting notes.</p> */}
+        <p>
+          In past years, the Town Hall has been a huge driver of student
+          feedback and improvements to curriculum; this includes:
+        </p>
+        <ul>
+          <li>The rework of CS35L (and CS97)</li>
+          <li>The start of engineering-wide ethics reform</li>
+          <li>More leniency around the sci-tech and tech breadth electives</li>
+          <li>Reduction of the Physics Lab Requirement from 2 classes to 1</li>
+          <li>Removal of the chemistry requirement from the CS degree </li>
+        </ul>
+        <p>
+          The town hall is jointly held by ACM at UCLA, exploretech.la, UPE at
+          UCLA, and the Department of Computer Science at UCLA.
+        </p>
+        <ul className="list-unstyled text-center">
+          <li style={inlineButtonListStyle}>
+            <Link href={townHall.rsvp}>
+              <a className="button" target = "_blank">
+                <FontAwesomeIcon
+                  icon={faFileAlt}
+                  fixedWidth
+                  aria-hidden={true}
+                />{' '}
+                RSVP Here!
+              </a>
+            </Link>
+          </li>
+        </ul>
+        <hr />
+      </div>
+      <div className="content-container-medium">
+        <div className="grid-tablet-2">
+          <div>
+            <h2 id="surveys">Surveys</h2>
+            <p>
+              {/* eslint-disable-next-line max-len */}
+              We use pre-event surveys to gauge students&apos; opinions on{' '}
+              <b>diversity &amp; inclusion</b>, <b>academics and curriculum</b>,
+              and <b>teaching practices</b>. The {townHall.quarter} Town Hall&apos;s focus is on
+              your questions so we only have <b>one survey.</b> We use the
+              answers to present problems to the CS department and guide the
+              discussion. <b>Survey responses are anonymous!</b>
+            </p>
+            <p>
+              We need to hear your voice! Please answer this survey before the
+              event.
+            </p>
+            <Link href={townHall.survey}>
+              <a className="button" target="_blank" rel="noopener noreferrer">
+                <FontAwesomeIcon
+                  icon={faFileAlt}
+                  fixedWidth
+                  aria-hidden={true}
+                />{' '}
+                CS Town Hall Survey
+              </a>
+            </Link>
+          </div>
+          <div>
+            <Image
+              src={TestimonialsCourseChanges}
+              alt="A slide from the winter 2021 town hall titled 'courses students wish to see changes in', with several different examples (CS 111, 152A, 131, 1)"
+            />
+          </div>
+        </div>
+        <hr />
+      </div>
+      <div className="content-container-medium">
+        <h2 className="text-center">Past Town Halls</h2>
+        <div className="grid-tablet-2">
+          <div>
+            <h3>Fall 2022 // Wednesday, Nov 9th 2022</h3>
+            <p>
+              At our Fall 2022 Town Hall, we centered our attention on several important topics,
+              including proposed reforms to the Computer Science curriculum, exploring research
+              opportunities for undergraduates, and ongoing discussions around enabling students
+              to provide anonymous feedback to faculty members.
+            </p>
+            <ul className="list-unstyled">
+              <li style={inlineButtonListStyle}>
+                <Link href="https://docs.google.com/presentation/d/14MIk1bzHHr5b11cgYX_kAz5WQa6ToKD_9nnj3_5DLco/edit?usp=sharing">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Form Summaries and Slides
+                  </a>
+                </Link>
+              </li>{' '}
+              <li style={inlineButtonListStyle}>
+                <Link href="https://docs.google.com/document/d/1JTFaP27OsqA0sBhjbIC4mIzjCgqRLJyBxvOQ5FSrPCk/edit?usp=sharing">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Event Notes
+                  </a>
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <Image
+              src={F22TownHallBanner}
+              alt="Fall 2022 Computer Science Town Hall Banner."
+              width={embedWidth}
+              height={(embedWidth * 315) / 560}
+              layout="fixed"
+            />
+          </div>
+        </div>
+        <div className="grid-tablet-2">
+          <div>
+            <h3>Spring 2022 // Wednesday, May 11th 2022</h3>
+            <p>
+              In our Spring 2022 Town Hall, we focused on identifying effective
+              teaching practices and dicussed the curriculum reform with the
+              CS department while enabling more students to directly address their concerns
+              with professors and the department&apos;s leadership.
+            </p>
+            <ul className="list-unstyled">
+              <li style={inlineButtonListStyle}>
+                <Link href="https://docs.google.com/presentation/d/1L9dSMVUr1TSazZu0-LqSHRSjEMMOO4GG-kZlOrkAjOM/edit?usp=sharing">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Form Summaries and Slides
+                  </a>
+                </Link>
+              </li>{' '}
+              <li style={inlineButtonListStyle}>
+                <Link href="https://docs.google.com/document/d/1QADyPwSqwf4cS_O51klvqA8dAcNlOXF1zT5YThi78q4/edit?usp=sharing">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Event Notes
+                  </a>
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <Image
+              src={SpringTownhallImage}
+              alt="A photograph from the Spring 2022 Computer Science Town Hall. Professor Eggert is introducing himself and other professors are sitting beside him."
+              width={embedWidth}
+              height={(embedWidth * 315) / 560}
+              layout="fixed"
+            />
+          </div>
+        </div>
+        <div className="grid-tablet-2">
+          <div>
+            <h3>Fall 2021 // Wednesday, November 10th 2021</h3>
+            <p>
+              In our Fall 2021 Town Hall, we continued the conversation on
+              critical issues such as inclusion and curriculum reform with the
+              CS department while empowering students to share their concerns
+              with professors and the department&apos;s leadership.
+            </p>
+            <ul className="list-unstyled">
+              <li style={inlineButtonListStyle}>
+                <Link href="/files/town-hall/CS Town Hall Fall 2021 Slides.pdf">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Form Summaries and Slides
+                  </a>
+                </Link>
+              </li>{' '}
+              <li style={inlineButtonListStyle}>
+                <Link href="/files/town-hall/CS Town Hall Fall 2021 Notes.pdf">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Event Notes
+                  </a>
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <Image
+              src={TownHallFall2021Attending}
+              alt="A banner that reads 'Spring 2022 Computer Science Town Hall: ask questions and be heard! Wednesday, May 11 from 6:00 - 8:00 PM PT. Mong Learning Center, Engineering VI. Ask Questions and get your voice heard!'"
+              width={embedWidth}
+              height={(embedWidth * 315) / 560}
+              layout="fixed"
+            />
+          </div>
+        </div>
+        <div className="grid-tablet-2">
+          <div>
+            <h3>Winter 2021 // Wednesday, February 24th 2021</h3>
+            <p>
+              {/* eslint-disable-next-line max-len */}
+              In our first ever fully-virtual town hall, we focused on three key
+              topics: academics &amp; curriculum, academic honesty, and a new
+              section devoted to diversity &amp; inclusion.
+            </p>
+            <ul className="list-unstyled">
+              <li style={inlineButtonListStyle}>
+                <Link href="/files/town-hall/CS Town Hall Winter 2021 Slides.pdf">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Form Summaries and Slides
+                  </a>
+                </Link>
+              </li>{' '}
+              <li style={inlineButtonListStyle}>
+                <Link href="/files/town-hall/CS Town Hall Winter 2021 Notes.pdf">
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Event Notes
+                  </a>
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div ref={embed2021WRef}>
+            <iframe
+              width={embedWidth}
+              height={(embedWidth * 315) / 560}
+              src={TOWN_HALL_2021_WINTER_VIDEO}
+              title="YouTube video player"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+export default TownHall;

--- a/pages/town-hall/town-hall.js
+++ b/pages/town-hall/town-hall.js
@@ -8,10 +8,8 @@ import React, { useRef } from 'react';
 import Banner from '../../components/Banner';
 import Layout from '../../components/Layout';
 
-import SpringTownhallImage from '../../public/images/spring-2022-townhall-photo.JPG';
+import pastData from '../../past-townhall.json';
 import TestimonialsCourseChanges from '../../public/images/town-hall/testimonials-course-changes.png';
-import TownHallFall2021Attending from '../../public/images/town-hall/town-hall-attending-f21.jpeg';
-import F22TownHallBanner from '../../public/images/town-hall/town-hall-banner-f22.png';
 import data from '../../townhall.json';
 
 const TOWN_HALL_2021_WINTER_VIDEO = 'https://www.youtube.com/embed/Eq2xsShPMVc';
@@ -38,6 +36,9 @@ function TownHall() {
     rsvp: '',
     survey: '',
   };
+
+  // Reverse pastData from past-townhall.json
+  const pastTownHalls = [...pastData].reverse();
 
   // Fetch and assign data from townhall.json
   for(let row of data) {
@@ -95,6 +96,7 @@ function TownHall() {
           site_name: 'ACM at UCLA',
         }}
       />
+      {/* Most Recent Town Hall*/}
       <Banner decorative />
       <div className="content-container-tight">
         <div className="text-center">
@@ -148,6 +150,7 @@ function TownHall() {
         </ul>
         <hr />
       </div>
+      {/* Surveys */}
       <div className="content-container-medium">
         <div className="grid-tablet-2">
           <div>
@@ -185,170 +188,61 @@ function TownHall() {
         </div>
         <hr />
       </div>
+      {/* Past Town Halls */}
       <div className="content-container-medium">
         <h2 className="text-center">Past Town Halls</h2>
-        <div className="grid-tablet-2">
-          <div>
-            <h3>Fall 2022 // Wednesday, Nov 9th 2022</h3>
-            <p>
-              At our Fall 2022 Town Hall, we centered our attention on several important topics,
-              including proposed reforms to the Computer Science curriculum, exploring research
-              opportunities for undergraduates, and ongoing discussions around enabling students
-              to provide anonymous feedback to faculty members.
-            </p>
-            <ul className="list-unstyled">
-              <li style={inlineButtonListStyle}>
-                <Link href="https://docs.google.com/presentation/d/14MIk1bzHHr5b11cgYX_kAz5WQa6ToKD_9nnj3_5DLco/edit?usp=sharing">
-                  <a
-                    className="button"
-                    target="_blank"
-                    rel="noopener noreferrer"
+        {pastTownHalls.map((pastTownHall, index) => (
+          <div className="grid-tablet-2" key={index}>
+            <div>
+              <h3>{pastTownHall.title + ' // ' + pastTownHall.date}</h3>
+              <p>{pastTownHall.description}</p>
+              <ul className="list-unstyled">
+                <li style={inlineButtonListStyle}>
+                  <Link href={pastTownHall.slides}>
+                    <a
+                      className="button"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      >
+                      <FontAwesomeIcon
+                        icon={faFileAlt}
+                        fixedWidth
+                        aria-hidden={true}
+                      />{' '}
+                      Form Summaries and Slides
+                    </a>
+                  </Link>
+                </li>{' '}
+                <li style={inlineButtonListStyle}>
+                  <Link href={pastTownHall.notes}>
+                    <a
+                      className="button"
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
-                    <FontAwesomeIcon
-                      icon={faFileAlt}
-                      fixedWidth
-                      aria-hidden={true}
-                    />{' '}
-                    Form Summaries and Slides
-                  </a>
-                </Link>
-              </li>{' '}
-              <li style={inlineButtonListStyle}>
-                <Link href="https://docs.google.com/document/d/1JTFaP27OsqA0sBhjbIC4mIzjCgqRLJyBxvOQ5FSrPCk/edit?usp=sharing">
-                  <a
-                    className="button"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <FontAwesomeIcon
-                      icon={faFileAlt}
-                      fixedWidth
-                      aria-hidden={true}
-                    />{' '}
-                    Event Notes
-                  </a>
-                </Link>
-              </li>
-            </ul>
+                      <FontAwesomeIcon
+                        icon={faFileAlt}
+                        fixedWidth
+                        aria-hidden={true}
+                      />{' '}
+                      Event Notes
+                    </a>
+                  </Link>
+                </li>
+              </ul>
+            </div>
+            <div>
+              <Image
+                src={pastTownHall.banner}
+                alt={pastTownHall.alt_text}
+                width={embedWidth}
+                height={(embedWidth * 315) / 560}
+                layout="fixed"
+              />
+            </div>
           </div>
-          <div>
-            <Image
-              src={F22TownHallBanner}
-              alt="Fall 2022 Computer Science Town Hall Banner."
-              width={embedWidth}
-              height={(embedWidth * 315) / 560}
-              layout="fixed"
-            />
-          </div>
-        </div>
-        <div className="grid-tablet-2">
-          <div>
-            <h3>Spring 2022 // Wednesday, May 11th 2022</h3>
-            <p>
-              In our Spring 2022 Town Hall, we focused on identifying effective
-              teaching practices and dicussed the curriculum reform with the
-              CS department while enabling more students to directly address their concerns
-              with professors and the department&apos;s leadership.
-            </p>
-            <ul className="list-unstyled">
-              <li style={inlineButtonListStyle}>
-                <Link href="https://docs.google.com/presentation/d/1L9dSMVUr1TSazZu0-LqSHRSjEMMOO4GG-kZlOrkAjOM/edit?usp=sharing">
-                  <a
-                    className="button"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    >
-                    <FontAwesomeIcon
-                      icon={faFileAlt}
-                      fixedWidth
-                      aria-hidden={true}
-                    />{' '}
-                    Form Summaries and Slides
-                  </a>
-                </Link>
-              </li>{' '}
-              <li style={inlineButtonListStyle}>
-                <Link href="https://docs.google.com/document/d/1QADyPwSqwf4cS_O51klvqA8dAcNlOXF1zT5YThi78q4/edit?usp=sharing">
-                  <a
-                    className="button"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <FontAwesomeIcon
-                      icon={faFileAlt}
-                      fixedWidth
-                      aria-hidden={true}
-                    />{' '}
-                    Event Notes
-                  </a>
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <Image
-              src={SpringTownhallImage}
-              alt="A photograph from the Spring 2022 Computer Science Town Hall. Professor Eggert is introducing himself and other professors are sitting beside him."
-              width={embedWidth}
-              height={(embedWidth * 315) / 560}
-              layout="fixed"
-            />
-          </div>
-        </div>
-        <div className="grid-tablet-2">
-          <div>
-            <h3>Fall 2021 // Wednesday, November 10th 2021</h3>
-            <p>
-              In our Fall 2021 Town Hall, we continued the conversation on
-              critical issues such as inclusion and curriculum reform with the
-              CS department while empowering students to share their concerns
-              with professors and the department&apos;s leadership.
-            </p>
-            <ul className="list-unstyled">
-              <li style={inlineButtonListStyle}>
-                <Link href="/files/town-hall/CS Town Hall Fall 2021 Slides.pdf">
-                  <a
-                    className="button"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <FontAwesomeIcon
-                      icon={faFileAlt}
-                      fixedWidth
-                      aria-hidden={true}
-                    />{' '}
-                    Form Summaries and Slides
-                  </a>
-                </Link>
-              </li>{' '}
-              <li style={inlineButtonListStyle}>
-                <Link href="/files/town-hall/CS Town Hall Fall 2021 Notes.pdf">
-                  <a
-                    className="button"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <FontAwesomeIcon
-                      icon={faFileAlt}
-                      fixedWidth
-                      aria-hidden={true}
-                    />{' '}
-                    Event Notes
-                  </a>
-                </Link>
-              </li>
-            </ul>
-          </div>
-          <div>
-            <Image
-              src={TownHallFall2021Attending}
-              alt="A banner that reads 'Spring 2022 Computer Science Town Hall: ask questions and be heard! Wednesday, May 11 from 6:00 - 8:00 PM PT. Mong Learning Center, Engineering VI. Ask Questions and get your voice heard!'"
-              width={embedWidth}
-              height={(embedWidth * 315) / 560}
-              layout="fixed"
-            />
-          </div>
-        </div>
+        ))}
+
         <div className="grid-tablet-2">
           <div>
             <h3>Winter 2021 // Wednesday, February 24th 2021</h3>

--- a/scripts/town-hall-generator.mjs
+++ b/scripts/town-hall-generator.mjs
@@ -57,7 +57,7 @@ async function fetchTownHallData() {
 }
 
 async function fetchPastTownHallData() {
-  const data = await getGoogleSheetData('PastTownHalls!A2:G');
+  const data = await getGoogleSheetData('PastTownHalls!A3:G');
 
   // Format the rows into an array of objects
   const formattedData = data.map((row) => ({

--- a/scripts/town-hall-generator.mjs
+++ b/scripts/town-hall-generator.mjs
@@ -1,0 +1,90 @@
+import fs from 'fs';
+import dotenv from 'dotenv';
+import { google } from 'googleapis';
+
+// .env config
+dotenv.config();
+const SPREADSHEET_ID = process.env?.TOWNHALL_SPREADSHEET_ID;
+const SERVICE_ACCOUNT = process.env?.SERVICE_ACCOUNT;
+
+// Output json file
+writeAllOutputs();
+
+// Read data from Google sheets
+// using sheet range (TownHall!A:H)
+async function getGoogleSheetData(range) {
+  const sheets = google.sheets({ version: 'v4' });
+
+  // Get JWT Token to access sheet
+  const service_account = JSON.parse(SERVICE_ACCOUNT);
+  const jwtClient = new google.auth.JWT(
+    service_account.client_email,
+    null, // or undefined, or an empty string (depends on your use case)
+    service_account.private_key,
+    ['https://www.googleapis.com/auth/spreadsheets'],
+  );
+
+  // Authorize the client
+  await jwtClient.authorize();
+
+  // Get data from Google spreadsheets
+  const res = await sheets.spreadsheets.values.get({
+    auth: jwtClient,
+    spreadsheetId: SPREADSHEET_ID,
+    range: range,
+  });
+
+  const rows = res?.data.values;
+  if (!rows || rows.length == 0) {
+    // eslint-disable-next-line no-console
+    console.log('Error: no data found');
+    return [];
+  }
+
+  return rows;
+}
+
+async function fetchTownHallData() {
+  const data = await getGoogleSheetData('TownHall!A:B');
+
+  // Format the rows into an array of objects
+  const formattedData = data.map((row) => ({
+    name: row[0],
+    description: row[1],
+  }));
+
+  return formattedData;
+}
+
+async function fetchPastTownHallData() {
+  const data = await getGoogleSheetData('PastTownHalls!A2:G');
+
+  // Format the rows into an array of objects
+  const formattedData = data.map((row) => ({
+    title: row[0],
+    date: row[1],
+    description: row[2],
+    slides: row[3],
+    notes: row[4],
+    banner: row[5],
+    alt_text: row[6],
+  }));
+
+  return formattedData;
+}
+
+// Write data from sheets to a json file
+async function writeToOutput(name, formattedData) {
+  const output = JSON.stringify(formattedData);
+  fs.writeFile(name, output, (err) => {
+    if (err) throw err;
+    // eslint-disable-next-line no-console
+    console.log('Output successfully saved to', name);
+  });
+}
+
+// Outputs all necessary json files
+async function writeAllOutputs() {
+  writeToOutput('townhall.json', await fetchTownHallData());
+  writeToOutput('past-townhall.json', await fetchPastTownHallData());
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -347,45 +347,18 @@
   "integrity" "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg=="
   "resolved" "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz"
   "version" "7.22.19"
-  "integrity" "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg=="
-  "resolved" "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz"
-  "version" "7.22.19"
   dependencies:
     "@babel/helper-string-parser" "^7.22.5"
     "@babel/helper-validator-identifier" "^7.22.19"
     "to-fast-properties" "^2.0.0"
-    "to-fast-properties" "^2.0.0"
 
 "@babel/types@^7.22.15":
   "integrity" "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg=="
   "resolved" "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz"
   "version" "7.23.0"
-"@babel/types@^7.22.15":
-  "integrity" "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg=="
-  "resolved" "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz"
-  "version" "7.23.0"
   dependencies:
     "@babel/helper-string-parser" "^7.22.5"
     "@babel/helper-validator-identifier" "^7.22.20"
-    "to-fast-properties" "^2.0.0"
-
-"@babel/types@^7.22.5":
-  "integrity" "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg=="
-  "resolved" "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz"
-  "version" "7.23.0"
-  dependencies:
-    "@babel/helper-string-parser" "^7.22.5"
-    "@babel/helper-validator-identifier" "^7.22.20"
-    "to-fast-properties" "^2.0.0"
-
-"@babel/types@^7.23.0":
-  "integrity" "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg=="
-  "resolved" "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz"
-  "version" "7.23.0"
-  dependencies:
-    "@babel/helper-string-parser" "^7.22.5"
-    "@babel/helper-validator-identifier" "^7.22.20"
-    "to-fast-properties" "^2.0.0"
     "to-fast-properties" "^2.0.0"
 
 "@babel/types@^7.22.5":
@@ -425,15 +398,6 @@
     "js-yaml" "^3.13.1"
     "minimatch" "^3.0.4"
     "strip-json-comments" "^3.1.1"
-    "ajv" "^6.12.4"
-    "debug" "^4.1.1"
-    "espree" "^7.3.0"
-    "globals" "^13.9.0"
-    "ignore" "^4.0.6"
-    "import-fresh" "^3.2.1"
-    "js-yaml" "^3.13.1"
-    "minimatch" "^3.0.4"
-    "strip-json-comments" "^3.1.1"
 
 "@fortawesome/fontawesome-common-types@6.4.2":
   "integrity" "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA=="
@@ -453,8 +417,9 @@
     "@fortawesome/fontawesome-common-types" "6.4.2"
 
 "@fortawesome/free-brands-svg-icons@^6.4.2":
-  version "6.4.2"
-  resolved "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.2.tgz"
+  "integrity" "sha512-LKOwJX0I7+mR/cvvf6qIiqcERbdnY+24zgpUSouySml+5w8B4BJOx8EhDR/FTKAu06W12fmUIcv6lzPSwYKGGg=="
+  "resolved" "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.4.2.tgz"
+  "version" "6.4.2"
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.4.2"
 
@@ -797,9 +762,9 @@
   "resolved" "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.4.tgz"
   "version" "11.1.4"
 
-"@next/swc-darwin-arm64@11.1.4":
-  "integrity" "sha512-jt8dMtIRWnJjRYLid6NWCxXzXdpr9VFT/vhDp8ioh+TtOR0UKPHMxei6R4GA3RqoyPEfFcSNmkG7OtyqCSxNIw=="
-  "resolved" "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.4.tgz"
+"@next/swc-linux-x64-gnu@11.1.4":
+  "integrity" "sha512-QfVuXugxBkCUHN9yD/VZ1xqszcMlBDj6vrbRiQvmWuyNo39ON6HqGn3jDwVrTHc9oKo2a0XInm+0zEnQeDmjSw=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.4.tgz"
   "version" "11.1.4"
 
 "@node-rs/helper@1.2.1":
@@ -3011,11 +2976,6 @@
   "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
-
-"fsevents@^2.3.2", "fsevents@~2.3.1":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
 
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="


### PR DESCRIPTION
![townhall](https://github.com/uclaacm/website/assets/77220087/9b01737a-3322-4360-9f80-f8b2b287990e)

## Overview

Resolves #673 by creating a dynamic town hall page (`town-hall.js`) in the `/pages/` directory. This page populates the website with data retrieved from two JSON files: `townhall.json` and `past-townhall.json`. The two JSON files are generated by the script (`town-hall-generator.mjs`), which runs before the build process to fetch data from this [spreadsheet](https://docs.google.com/spreadsheets/d/1biy1JE3MaBqGpCAxTstEkE1pnJekFRKJEnbvoXcwZOQ/edit?usp=sharing). For testing, access the page at [localhost:3000/town-hall/](http://localhost:3000/town-hall/) through the development server.


## Changes

`pages/town-hall.js` (NEW)
- Removed all unused imports
- Moved `town-hall.js` from `/pages/town-hall/` to `/pages/` for ease of access
- Dynamically updates SEO data
- Auto-populates all visible information on the website
- Replaces empty data fields with a placeholder (e.g., [Time])

`scripts/town-hall-generator.mjs` (NEW)
- Generates two JSON files: `townhall.json` and `past-townhall.json`
- Retrieves data from this [spreadsheet](https://docs.google.com/spreadsheets/d/1biy1JE3MaBqGpCAxTstEkE1pnJekFRKJEnbvoXcwZOQ/edit?usp=sharing) using `googleapi`

`package.json`
- Added `thp` script: `node scripts/town-hall-generator.mjs`
- Added `npm run thp` in the build script

`.gitignore`:
- Added `townhall.json` and `past-townhall.json`

`next.config.js`
- Added `www.uclaacm.com` under allowed domains for images

`_redirects`
- Removed redirect on `/town-hall/`

`netlify.toml`
- Added `npm run thp` before `npm build`

`lint.yml`
- Added ` run: npm run thp`
- Centralized environment variable declaration

`node-build.yml`
- Added `- run: npm run thp`
- Centralized environment variable declaration

## Possible Changes
- Currently, out of all the past town hall meetings, the Winter 2021 Town Hall data is not retrieved from the spreadsheet because it displays a video instead of a banner. If needed, fixes can be made in `pages/town-hall.js` to support videos in the future
- All the old town hall pages are still under the `/pages/town-hall/` directory. We can either delete them or leave them for the users to access (e.g. https://www.uclaacm.com/town-hall/f23)