### PR TITLE
Crops non 1:1 officer images to prevent stretching

### DIFF
--- a/components/Officers/OfficerCard.js
+++ b/components/Officers/OfficerCard.js
@@ -28,6 +28,7 @@ function Officer({
                 alt={alt}
                 width={130}
                 height={130}
+                objectFit="cover" // Crop to fit the aspect ratio
                 unoptimized={true}
               />
             </div>


### PR DESCRIPTION
## Describe your changes

Non-square officer images get shrunk to fit to a 1:1 aspect ratio. This fixes that issue (for the /officers page, /dev renders the full photo).

"objectFit="cover" // Crop to fit the aspect ratio" added to the OfficerCard component

Before:
![image](https://github.com/user-attachments/assets/ee2ac963-606d-4496-8edb-a086b333112c)
After:
![image](https://github.com/user-attachments/assets/cb3ab084-85e8-4076-a1e4-541ffb2104dd)

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
