### PR TITLE
removes map when vw < 600px

### DIFF
--- a/pages/gm.js
+++ b/pages/gm.js
@@ -223,10 +223,10 @@ function gm() {
               <iframe
                 src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin"
                 style={{ width: '100%', height: '100%'}}
-                allowFullScreen=""
-                loading="lazy"
-                title="google maps embed of ackerman grand ballroom"
-                referrerPolicy="no-referrer-when-downgrade"
+                allowFullScreen=''
+                loading='lazy'
+                title='google maps embed of ackerman grand ballroom'
+                referrerPolicy='no-referrer-when-downgrade'
               ></iframe>
             </div>
             <div className='what-to-bring'>

--- a/pages/gm.js
+++ b/pages/gm.js
@@ -219,7 +219,20 @@ function gm() {
         <div id='info-wrapper'>
           <h2>Relevant information</h2>
           <div className='flex'>
-            <div>
+            <style>
+              {`
+                .map-container {
+                  display: none;
+                }
+
+                @media (min-width: 600px) {
+                  .map-container {
+                    display: block;
+                  }
+                }
+              `}
+            </style>
+            <div class="map-container">
               <iframe src='https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin' width='450' height='400' style={{border: 0}} allowfullscreen='' loading='lazy' title='google maps embed of ackerman grand ballroom' referrerPolicy='no-referrer-when-downgrade'></iframe>
             </div>
             <div className='what-to-bring'>

--- a/pages/gm.js
+++ b/pages/gm.js
@@ -219,13 +219,13 @@ function gm() {
         <div id='info-wrapper'>
           <h2>Relevant information</h2>
           <div className='flex map-container'>
-            <div style={{flexGrow: 1, width: "100%"}}>
-              <iframe 
-                src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin" 
-                style={{ width: "100%", height: "100%"}} 
+            <div style={{flexGrow: 1, width: '100%'}}>
+              <iframe
+                src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin"
+                style={{ width: '100%', height: '100%'}}
                 allowFullScreen=""
-                loading="lazy" 
-                title="google maps embed of ackerman grand ballroom" 
+                loading="lazy"
+                title="google maps embed of ackerman grand ballroom"
                 referrerPolicy="no-referrer-when-downgrade"
               ></iframe>
             </div>

--- a/pages/gm.js
+++ b/pages/gm.js
@@ -218,11 +218,11 @@ function gm() {
 			<div className='content-container-tight text-center'>
         <div id='info-wrapper'>
           <h2>Relevant information</h2>
-          <div className='flex map-container'>
-            <div style={{flexGrow: 1, width: '100%'}}>
+          <div className='flex rel-info'>
+            <div className='map-container'>
               <iframe
-                src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin"
-                style={{ width: '100%', height: '100%'}}
+                src='https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin'
+                className='map-frame'
                 allowFullScreen=''
                 loading='lazy'
                 title='google maps embed of ackerman grand ballroom'

--- a/pages/gm.js
+++ b/pages/gm.js
@@ -218,22 +218,16 @@ function gm() {
 			<div className='content-container-tight text-center'>
         <div id='info-wrapper'>
           <h2>Relevant information</h2>
-          <div className='flex'>
-            <style>
-              {`
-                .map-container {
-                  display: none;
-                }
-
-                @media (min-width: 600px) {
-                  .map-container {
-                    display: block;
-                  }
-                }
-              `}
-            </style>
-            <div class="map-container">
-              <iframe src='https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin' width='450' height='400' style={{border: 0}} allowfullscreen='' loading='lazy' title='google maps embed of ackerman grand ballroom' referrerPolicy='no-referrer-when-downgrade'></iframe>
+          <div className='flex map-container'>
+            <div style={{flexGrow: 1, width: "100%"}}>
+              <iframe 
+                src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d13219.85897956824!2d-118.4441451!3d34.070418!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x62f97fe423993f80!2sUCLA%20Ackerman%20Union!5e0!3m2!1sen!2sin!4v1663063464157!5m2!1sen!2sin" 
+                style={{ width: "100%", height: "100%"}} 
+                allowFullScreen=""
+                loading="lazy" 
+                title="google maps embed of ackerman grand ballroom" 
+                referrerPolicy="no-referrer-when-downgrade"
+              ></iframe>
             </div>
             <div className='what-to-bring'>
               <h3>How to get there</h3>

--- a/styles/components/GM.scss
+++ b/styles/components/GM.scss
@@ -123,6 +123,10 @@
   text-decoration: none;
 }
 
+.map-container {
+  height: 400px;
+}
+
 .flex {
   display: flex;
 
@@ -138,6 +142,20 @@
   .what-to-bring {
     margin-left: 25px;
     text-align: left;
+  }
+}
+
+@media (max-width: 640px) {
+  .map-container {
+    height: 450px;
+    flex-direction: column;
+  }
+
+  .flex { 
+    .what-to-bring{
+      margin-left: 0;
+      margin-top: 15px;
+    }
   }
 }
 

--- a/styles/components/GM.scss
+++ b/styles/components/GM.scss
@@ -147,12 +147,12 @@
 
 @media (max-width: 640px) {
   .map-container {
-    height: 450px;
     flex-direction: column;
+    height: 450px;
   }
 
   .flex { 
-    .what-to-bring{
+    .what-to-bring {
       margin-left: 0;
       margin-top: 15px;
     }

--- a/styles/components/GM.scss
+++ b/styles/components/GM.scss
@@ -123,8 +123,18 @@
   text-decoration: none;
 }
 
-.map-container {
+.rel-info {
   height: 400px;
+}
+
+.map-container {
+  flex-grow: 1;
+  width: 100%;
+}
+
+.map-frame {
+  height: 100%;
+  width: 100%;
 }
 
 .flex {
@@ -146,7 +156,7 @@
 }
 
 @media (max-width: 640px) {
-  .map-container {
+  .rel-info {
     flex-direction: column;
     height: 450px;
   }


### PR DESCRIPTION
## Describe your changes

Hides the embedded Google Maps on the GM page when VW < 600px. This will keep the page responsive and prevent stretching.

## Issue ticket number and link
Fixes Issue #721 


## Checklist before requesting a review
- [x] I have performed a self-review of my code
