### PR TITLE
fix: added word-break to prevent overflowing text on event cards

### DIFF
--- a/styles/components/Events/SelectedEvent.module.scss
+++ b/styles/components/Events/SelectedEvent.module.scss
@@ -39,6 +39,7 @@
 .description {
   font-size: 0.8rem;
   margin: 0.5em 0;
+  word-break: break-word;
 }
 
 .event-link {


### PR DESCRIPTION
<!--
    Tag your PR title with the components it touches along with the type of change (feat, fix, refactor)
    eg. feat: update internship page timeline
-->

## Overview

Deploy Preview: [https://deploy-preview-749--jovial-pasteur-581b4a.netlify.app/events](https://deploy-preview-749--jovial-pasteur-581b4a.netlify.app/events)

## Changes
 - Added a word-break within the event cards on the events page to prevent links from overflowing


## Testing

<img width="593" alt="image" src="https://github.com/user-attachments/assets/250266db-fa69-4d2f-9ced-6c738d6eb498" />


## Possible Changes

- Could make links clickable on events page

## Checklist
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated where necessary.
- [x] All checks pass and deploy builds with no errors.
