### PR TITLE
fix: past townhall slides button changed to be conditionally rendered

### DIFF
--- a/pages/town-hall.js
+++ b/pages/town-hall.js
@@ -189,8 +189,9 @@ function TownHall() {
 
         {townHall.status ? (
           <p>
-            The {townHall.quarter} Town Hall took place on <b>{townHall.date}</b> (Week {townHall.week})
-            at <b>{townHall.time} PT</b> in the {townHall.location}.
+            The {townHall.quarter} Town Hall took place on{' '}
+            <b>{townHall.date}</b> (Week {townHall.week}) at{' '}
+            <b>{townHall.time} PT</b> in the {townHall.location}.
           </p>
         ) : (
           <p style={TBD}>{townHall.status_text}</p>
@@ -344,7 +345,25 @@ function TownHall() {
                       Event Notes
                     </a>
                   </Link>
-                </li>
+                </li>{' '}
+                {pastTownHall.results && (
+                  <li style={inlineButtonListStyle}>
+                    <Link href={pastTownHall.results}>
+                      <a
+                        className="button"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <FontAwesomeIcon
+                          icon={faFileAlt}
+                          fixedWidth
+                          aria-hidden={true}
+                        />{' '}
+                        Results
+                      </a>
+                    </Link>
+                  </li>
+                )}
               </ul>
             </div>
             <div>

--- a/pages/town-hall.js
+++ b/pages/town-hall.js
@@ -314,22 +314,24 @@ function TownHall() {
               <h3>{pastTownHall.title + ' // ' + pastTownHall.date}</h3>
               <p>{pastTownHall.description}</p>
               <ul className="list-unstyled">
+                {pastTownHall.slides && 
                 <li style={inlineButtonListStyle}>
-                  <Link href={pastTownHall.slides}>
-                    <a
-                      className="button"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <FontAwesomeIcon
-                        icon={faFileAlt}
-                        fixedWidth
-                        aria-hidden={true}
-                      />{' '}
-                      Form Summaries and Slides
-                    </a>
-                  </Link>
-                </li>{' '}
+                <Link href={pastTownHall.slides}>
+                  <a
+                    className="button"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FontAwesomeIcon
+                      icon={faFileAlt}
+                      fixedWidth
+                      aria-hidden={true}
+                    />{' '}
+                    Form Summaries and Slides
+                  </a>
+                </Link>
+              </li>
+                }{' '}
                 <li style={inlineButtonListStyle}>
                   <Link href={pastTownHall.notes}>
                     <a

--- a/pages/town-hall.js
+++ b/pages/town-hall.js
@@ -314,24 +314,24 @@ function TownHall() {
               <h3>{pastTownHall.title + ' // ' + pastTownHall.date}</h3>
               <p>{pastTownHall.description}</p>
               <ul className="list-unstyled">
-                {pastTownHall.slides && 
-                <li style={inlineButtonListStyle}>
-                <Link href={pastTownHall.slides}>
-                  <a
-                    className="button"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <FontAwesomeIcon
-                      icon={faFileAlt}
-                      fixedWidth
-                      aria-hidden={true}
-                    />{' '}
-                    Form Summaries and Slides
-                  </a>
-                </Link>
-              </li>
-                }{' '}
+                {pastTownHall.slides && (
+                  <li style={inlineButtonListStyle}>
+                    <Link href={pastTownHall.slides}>
+                      <a
+                        className="button"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <FontAwesomeIcon
+                          icon={faFileAlt}
+                          fixedWidth
+                          aria-hidden={true}
+                        />{' '}
+                        Form Summaries and Slides
+                      </a>
+                    </Link>
+                  </li>
+                )}{' '}
                 <li style={inlineButtonListStyle}>
                   <Link href={pastTownHall.notes}>
                     <a

--- a/pages/town-hall.js
+++ b/pages/town-hall.js
@@ -359,7 +359,7 @@ function TownHall() {
                           fixedWidth
                           aria-hidden={true}
                         />{' '}
-                        Results
+                        Survey Results
                       </a>
                     </Link>
                   </li>

--- a/scripts/town-hall-generator.mjs
+++ b/scripts/town-hall-generator.mjs
@@ -57,7 +57,7 @@ async function fetchTownHallData() {
 }
 
 async function fetchPastTownHallData() {
-  const data = await getGoogleSheetData('PastTownHalls!A3:G');
+  const data = await getGoogleSheetData('PastTownHalls!A3:H');
 
   // Format the rows into an array of objects
   const formattedData = data.map((row) => ({
@@ -68,6 +68,7 @@ async function fetchPastTownHallData() {
     notes: row[4],
     banner: row[5],
     alt_text: row[6],
+    results: row[7],
   }));
 
   return formattedData;

--- a/styles/components/Events/SelectedEvent.module.scss
+++ b/styles/components/Events/SelectedEvent.module.scss
@@ -39,6 +39,7 @@
 .description {
   font-size: 0.8rem;
   margin: 0.5em 0;
+  word-break: break-word;
 }
 
 .event-link {


### PR DESCRIPTION
<!--
    Tag your PR title with the components it touches along with the type of change (feat, fix, refactor)
    eg. feat: update internship page timeline
-->

## Overview
- Button for Townhall slides were still being rendered, even when link does not exist

Deploy Preview: https://deploy-preview-751--jovial-pasteur-581b4a.netlify.app/town-hall

## Changes
<!-- 
    Summarize the changes made in this PR in bullet points
    List any new dependencies required for them 
-->

- Checks if slide link exists before rendering


## Checklist
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated where necessary.
- [x] All checks pass and deploy builds with no errors.
