### PR TITLE
Fixes Officer Parser failing when encountering a bad Google Drive Link

### DIFF
--- a/scripts/officer-parser.mjs
+++ b/scripts/officer-parser.mjs
@@ -70,8 +70,11 @@ async function getGoogleSheetData(range) {
             const url = new URL(image);
             const host = url.hostname;
             if (host === 'drive.google.com') {
-              const fileID = image.match(/\/file\/d\/(.+?)\//)[1]; //convert gdrive urls into viewable url using regex
-              image = `https://drive.google.com/thumbnail?id=${fileID}`;
+              const match = image.match(/\/file\/d\/(.+?)(?:\/|$)/);
+              if (match && match[1]) {
+                const fileID = match[1];
+                image = `https://drive.google.com/thumbnail?id=${fileID}`;
+              }
             } else if (host === 'github.com') {
               const regex =
                 /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/; //convert github urls into viewable url using regex


### PR DESCRIPTION
<!--
    Fixes Officer Parser failing when encountering a bad Google Drive image link.
-->

## Overview
Resolves #N/A

Deploy Preview: <!-- Add Netlify Link -->

## Changes
Previously a bad google drive link that still matched our regex expression would cause officer-parser.mjs to fail on build. This PR resolves that.

## Testing
Run `npm run build` and observe if any errors occur. Check whether the officers page loads properly.

## Possible Changes


## Checklist
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated where necessary.
- [x] All checks pass and deploy builds with no errors.
