### PR TITLE
remove eslint and eslint-config-next from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,12 @@ updates:
       interval: 'weekly'
     reviewers:
       - 'uclaacm/website-team'
+    
+    ignore:
+      # Don’t open PRs for eslint at all
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+
+      # Don’t open PRs for eslint-config-next at all
+      - dependency-name: "eslint-config-next"
+        update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
Remove eslint and eslint-config-next from dependabot updates. Eslint 9 requires a new completely flat config in eslint.config.mjs which honestly isn't what we need - Eslint 7 serves our use case.