### PR TITLE
Fix quarterly GM metadata description

### DIFF
--- a/pages/gm.js
+++ b/pages/gm.js
@@ -219,11 +219,20 @@ function gm() {
       />
     );
   }
+
+  const datetime = data.gm_start_time.toLocaleString('en-US', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    timeZoneName: 'short'
+  });
+
   return (
     <Layout>
       <NextSeo
         title={`${data.quarter} General Meeting | ACM at UCLA`}
-        description={`ACM's ${data.quarter} General Meeting will take place on ${data.gm_start_time.getMonth()} ${data.date_with_suffix} at ${data.gm_start_time.getHours()}:${data.gm_start_time.getMinutes()} PT!`}
+        description={`ACM's ${data.quarter} General Meeting will take place on ${datetime}!`}
         openGraph={{
           images: [
             {

--- a/pages/gm.js
+++ b/pages/gm.js
@@ -225,7 +225,7 @@ function gm() {
     day: 'numeric',
     hour: 'numeric',
     minute: 'numeric',
-    timeZoneName: 'short'
+    timeZoneName: 'short',
   });
 
   return (


### PR DESCRIPTION
## Changes

- Fixed GM page metadata by using JavaScript's built-in `Intl.DateTimeFormatter` object to properly display the GM meeting time in American 12-hour locale.

## Testing

1. Pull the latest changes using `git pull`.
2. Switch to this branch using `git checkout gm-meta-desc`.
3. Run `npm start` and navigate to the GM page.
4. Check the metadata inside the `head` tag for the meta-description.

## Checklist
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated where necessary.
- [ ] All checks pass and deploy builds with no errors.
