### PR TITLE
Fix: rerouted invite link of the main ACM Discord server to prevent web scrapers from finding it

### DIFF
--- a/components/SocialMedia.js
+++ b/components/SocialMedia.js
@@ -43,7 +43,7 @@ function SocialMedia(props) {
       </a>
       <a
         className="icon-link"
-        href="https://discord.gg/eWmzKsY"
+        href="/discord"
         target="_blank"
         rel="noreferrer noopener"
         aria-label="ACM at UCLA on Discord"

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/discord',
+        destination: 'https://discord.gg/eWmzKsY',
+        permanent: false, // 302 redirect
+      },
+    ];
+  },
+
   output: 'standalone',
   images: {
     remotePatterns: [


### PR DESCRIPTION
<!--
    Tag your PR title with the components it touches along with the type of change (feat, fix, refactor)
    eg. feat: update internship page timeline
-->

## Overview
Resolves #864 

Deploy Preview: https://uclaacmwebsite.netlify.app/

## Changes
- Rerouted invite link of the main ACM Discord server to uclaacm.com/discord
- Changed icon link to ```/discord``` in SocialMedia.js file
- Added ```redirect()``` function in ```next.config.js file```, pointing to the server invite
- No new dependencies required

## Testing
- Hover over the Discord icons on the website page to see if new link is there 

<img width="1512" height="825" alt="image" src="https://github.com/user-attachments/assets/3169ab4c-8a3e-4770-956d-cc0ae4f80757" />

## Possible Changes
- The Discord invite links for other ACM committees haven't been rerouted and are still there, which warrants future fixing

## Checklist
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated where necessary.
- [ ] All checks pass and deploy builds with no errors.
