### PR TITLE
Remove home page banner and associated imports

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -4,9 +4,9 @@ import { NextSeo } from 'next-seo';
 import { useState } from 'react';
 import Banner from '../components/Banner';
 import Carousel from '../components/Carousel';
-import CommitteeIcon from '../components/Committees/CommitteeIcon';
+//import CommitteeIcon from '../components/Committees/CommitteeIcon';
 import Committees from '../components/CommitteeSpread';
-import ContentBanner from '../components/ContentBanner';
+//import ContentBanner from '../components/ContentBanner';
 import Layout from '../components/Layout';
 import Article from '../components/NewsArticle';
 import SocialMedia from '../components/SocialMedia';
@@ -49,6 +49,7 @@ function Home() {
         }}
       />
       <div className="home-page text-center">
+        {/*
         <ContentBanner>
           <div className="content-banner-logos-top">
             <div className="content-banner-logos">
@@ -61,13 +62,11 @@ function Home() {
               <CommitteeIcon committee="teachLA" />
             </div>
           </div>
-          {/*
           <h2 className="content-banner-title">
             <Link href="/internship" style={{ marginRight: '8px', color: 'white' }}>
               ACM Internship Apps are now open!
             </Link>
           </h2>
-          */}
           <div className="content-banner-logos-top">
             <div className="content-banner-logos">
               <CommitteeIcon committee="acm" />
@@ -80,6 +79,7 @@ function Home() {
             </div>
           </div>
         </ContentBanner>
+        */}
         <Banner />
         <div className="content-section">
           <h2>The largest Computer Science community at UCLA</h2>


### PR DESCRIPTION
<!--
    Tag your PR title with the components it touches along with the type of change (feat, fix, refactor)
    eg. feat: update internship page timeline
-->

## Overview
Resolves #862 

Deploy Preview: https://deploy-preview-871--jovial-pasteur-581b4a.netlify.app/

## Changes

    Removed home page banner
    No new dependencies required



## Testing
    View the removed header at top of home page
<img width="1470" height="600" alt="Screenshot 2025-11-02 at 11 39 55 PM" src="https://github.com/user-attachments/assets/c1301a50-1d7f-4a01-8637-08a0001584fa" />


## Possible Changes

    Move icons from home page banner to the top of the home page


## Checklist
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated where necessary.
- [x] All checks pass and deploy builds with no errors.
