### PR TITLE
feat: Add Dev Team Leadership section above members

### DIFF
--- a/pages/dev.js
+++ b/pages/dev.js
@@ -8,8 +8,6 @@ import { projects } from '../data/dev';
 import data from '../data/officeroutput.json';
 import styles from '../styles/pages/Dev.module.scss';
 
-
-
 function DevTeam() {
   const devTeamExec = data.filter((officer) => {
     const role = officer.role || '';

--- a/pages/dev.js
+++ b/pages/dev.js
@@ -24,23 +24,21 @@ const devTeamAdvisor = {
 };
 
 function DevTeam() {
-  const devTeamExec = data.filter(officer => 
-    (officer.role.includes('Dev Team Director') || 
-     officer.role.includes('Dev Team Advisor') ||
-     officer.role.includes('Dev Team Project Manager')) && 
-    officer.committee.includes('Dev Team')
-  );
-  
-  const devTeamOfficers = data.filter(officer => 
-    officer.role.includes('Dev Team') && 
-    !officer.role.includes('Director') &&
-    !officer.role.includes('Advisor') &&
-    !officer.role.includes('Project Manager') &&
-    officer.committee.includes('Board, Dev Team')
-  );
+  const devTeamExec = data.filter((officer) => {
+    const role = officer.role || '';
+    const hasExecRole = role.includes('Director') || role.includes('Advisor') || role.includes('Project Manager');
+    return hasExecRole && officer.committee.includes('Dev Team');
+  });
+
+  const devTeamOfficers = data.filter((officer) => {
+    const role = officer.role || '';
+    const hasExecRole = role.includes('Director') || role.includes('Advisor') || role.includes('Project Manager');
+    const hasDevTeamRole = role.includes('Dev Team');
+    return hasDevTeamRole && !hasExecRole && officer.committee.includes('Board, Dev Team');
+  });
   devTeamOfficers.splice(1, 0, devTeamAdvisor);
   return (
-    (<Layout>
+    <Layout>
       <NextSeo
         title="ACM Dev Team | ACM at UCLA"
         description="The ACM Dev Team handles general internal development needs for ACM at UCLA. We maintain and create organization-wide projects such as the website, Discord bot, Membership Portal, and CMS Template."
@@ -88,7 +86,7 @@ function DevTeam() {
           <Officers officers={devTeamOfficers} />
         </div>
       </div>
-    </Layout>)
+    </Layout>
   );
 }
 

--- a/pages/dev.js
+++ b/pages/dev.js
@@ -24,7 +24,20 @@ const devTeamAdvisor = {
 };
 
 function DevTeam() {
-  const devTeamOfficers = data.filter(officer => officer.role.includes('Dev Team') && officer.committee.includes('Board, Dev Team'));
+  const devTeamExec = data.filter(officer => 
+    (officer.role.includes('Dev Team Director') || 
+     officer.role.includes('Dev Team Advisor') ||
+     officer.role.includes('Dev Team Project Manager')) && 
+    officer.committee.includes('Dev Team')
+  );
+  
+  const devTeamOfficers = data.filter(officer => 
+    officer.role.includes('Dev Team') && 
+    !officer.role.includes('Director') &&
+    !officer.role.includes('Advisor') &&
+    !officer.role.includes('Project Manager') &&
+    officer.committee.includes('Board, Dev Team')
+  );
   devTeamOfficers.splice(1, 0, devTeamAdvisor);
   return (
     (<Layout>
@@ -66,7 +79,11 @@ function DevTeam() {
             Github
           </Link>.
         </p>
-        <h2 className="text-center">People</h2>
+        <h2 className="text-center">Leadership</h2>
+        <div className="grid-desktop-3 text-center-mobile">
+          <Officers officers={devTeamExec} />
+        </div>
+        <h2 className="text-center">Members</h2>
         <div className="grid-desktop-3 text-center-mobile">
           <Officers officers={devTeamOfficers} />
         </div>

--- a/pages/dev.js
+++ b/pages/dev.js
@@ -8,20 +8,7 @@ import { projects } from '../data/dev';
 import data from '../data/officeroutput.json';
 import styles from '../styles/pages/Dev.module.scss';
 
-/*const devTeamDirector = {
-    name: 'Snigdha Kansal',
-    email: 'snigdha0206@g.ucla.edu',
-};*/
 
-const devTeamAdvisor = {
-  role: 'Dev Team Advisor',
-  name: 'Snigdha Kansal',
-  pronouns: 'she/her/hers',
-  year: '2025',
-  major: 'Computer Science',
-  photo:
-    'https://drive.google.com/thumbnail?id=1QMV2ifNFYNHZ1tEyVanN1cqxqTatzR16',
-};
 
 function DevTeam() {
   const devTeamExec = data.filter((officer) => {
@@ -36,7 +23,6 @@ function DevTeam() {
     const hasDevTeamRole = role.includes('Dev Team');
     return hasDevTeamRole && !hasExecRole && officer.committee.includes('Board, Dev Team');
   });
-  devTeamOfficers.splice(1, 0, devTeamAdvisor);
   return (
     <Layout>
       <NextSeo


### PR DESCRIPTION
Adds Leadership section for Dev Team executives (Director, Project Manager, Advisor) above Members section.

## Changes
- New `devTeamExec` filter for members with 'Dev Team Director', 'Dev Team Advisor', or 'Dev Team Project Manager' roles
- Display in 'Leadership' heading
- Members section now excludes exec roles to avoid duplication
- Auto-populates from officer data by role and committee fields

## Result
/dev page now shows:
1. Leadership section (executives)
2. Members section (officers)