### PR TITLE
fix: replace broken Qualcomm CDN logo with Wikimedia Commons SVG

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -97,7 +97,7 @@ function Home() {
           <div className="banner-center">
             <a href="https://www.qualcomm.com/company/careers/internships-and-early-in-career-opportunities">
               <img
-                src="https://cdn.cookielaw.org/logos/b0a5f2cc-0b29-4907-89bf-3f6b380a03c8/0814c8dd-07ff-41eb-a1b0-ee0294137c9a/9ca69c31-5e86-432d-950c-cfa7fcaa3cc8/1280px-Qualcomm-Logo.svg.png"
+                src="https://upload.wikimedia.org/wikipedia/commons/f/fc/Qualcomm-Logo.svg"
                 alt="Qualcomm Banner"
               />
             </a>


### PR DESCRIPTION

preview: https://deploy-preview-894--jovial-pasteur-581b4a.netlify.app/

**Issue:** Qualcomm logo on homepage links to broken cookielaw CDN, causing image load failure.

**Fix:** Replace with direct Wikimedia Commons SVG URL (same as sponsors.js already uses).

- From: `https://cdn.cookielaw.org/...` (broken)
- To: `https://upload.wikimedia.org/wikipedia/commons/f/fc/Qualcomm-Logo.svg` (reliable)

Matches the sponsors page which already uses the correct Wikimedia source.